### PR TITLE
Fix serializing response to json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Salestation
 
+[![Build Status](https://travis-ci.org/salemove/salestation.svg?branch=master)](https://travis-ci.org/salemove/salestation)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -23,7 +23,7 @@ module Salestation
           result = response.map_err(error_mapper.map).value
 
           status result.status
-          json JSON.dump(result.body)
+          json result.body
         end
       end
     end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.1.4"
+  spec.version       = "0.1.5"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/integration/failure_handling_spec.rb
+++ b/spec/integration/failure_handling_spec.rb
@@ -16,6 +16,10 @@ describe 'Failure handling' do
         CustomErrorClass => -> (error) { CustomErrorResponse }
       })
 
+      def json(input)
+        input.to_json
+      end
+
       def run
         app = Salestation::App.new(env: {})
         to_error = -> (request) { request.to_failure(CustomErrorClass.new) }
@@ -24,10 +28,6 @@ describe 'Failure handling' do
       end
 
       def status(*)
-      end
-
-      def json(input)
-        input
       end
     end
 

--- a/spec/salestation/web_spec.rb
+++ b/spec/salestation/web_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Salestation::Web do
+  class WebApp
+    include Salestation::Web.new(errors: {})
+
+    def json(input)
+      input.to_json
+    end
+
+    def status(*)
+    end
+  end
+
+  let(:web_app) { WebApp.new }
+
+  describe '#process' do
+    context 'when response is success' do
+      let(:response_body) { {response: 'response'} }
+      let(:response) {
+        Salestation::Web::Responses.to_ok.call(response_body)
+     }
+
+      it 'returns response body as json' do
+        expect(web_app.process(response)).to eql(JSON.dump(response_body))
+      end
+    end
+
+    context 'when response is failure' do
+      let(:response_body) { {message: 'error'} }
+      let(:response) {
+        Deterministic::Result::Success::Failure(response_body)
+      }
+
+      it 'returns error with debug message as json' do
+        expect(web_app.process(response)).to eql(JSON.dump(response_body.merge(debug_message: '')))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently it does

```
json JSON.dump(result.body)

```

`json` by itself doesn't seem to be defined in the Salestation, so
in junction with Sinatra it uses Sinatra's `json` which serializes
already serialized response second time.