### PR TITLE
Carry span information in the request object 

### DIFF
--- a/lib/salestation/app.rb
+++ b/lib/salestation/app.rb
@@ -22,8 +22,13 @@ module Salestation
       end
     end
 
-    def create_request(input)
-      Request.create(env: @environment, input: input, initialize_hook: method(:initialize_hook))
+    def create_request(input, span: nil)
+      Request.create(
+        env: @environment,
+        input: input,
+        initialize_hook: method(:initialize_hook),
+        span: span
+      )
     end
 
     def register_listener(hook_type, listener)

--- a/lib/salestation/app/request.rb
+++ b/lib/salestation/app/request.rb
@@ -1,18 +1,28 @@
 module Salestation
   class App
     class Request
-      def self.create(env:, input:, initialize_hook: nil)
-        new(env: env, input: input, initialize_hook: initialize_hook).to_success
+      def self.create(env:, input:, initialize_hook: nil, span: nil)
+        new(
+          env: env,
+          input: input,
+          initialize_hook: initialize_hook,
+          span: span
+        ).to_success
       end
 
-      attr_reader :env, :input
+      attr_reader :env, :input, :span
 
       def with_input(input_additions)
         replace_input(input.merge(input_additions))
       end
 
       def replace_input(new_input)
-        self.class.new(env: env, input: new_input, initialize_hook: @initialize_hook).to_success
+        self.class.new(
+          env: env,
+          input: new_input,
+          initialize_hook: @initialize_hook,
+          span: span
+        ).to_success
       end
 
       def to_success
@@ -33,10 +43,11 @@ module Salestation
 
       private
 
-      def initialize(env:, input:, initialize_hook:)
+      def initialize(env:, input:, initialize_hook: nil, span: nil)
         @env = env
         @input = input
         @initialize_hook = initialize_hook
+        @span = span
       end
     end
   end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.1.5"
+  spec.version       = "0.2.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/salestation/app/app_spec.rb
+++ b/spec/salestation/app/app_spec.rb
@@ -39,4 +39,23 @@ describe Salestation::App do
       end
     end
   end
+
+  describe '#create_request' do
+    context 'when span is given' do
+      it 'can be accessed' do
+        input = {}
+        span = double('span')
+        request = app.create_request(input, span: span).value
+        expect(request.span).to eq(span)
+      end
+    end
+
+    context 'when span is missing' do
+      it 'defaults to nil' do
+        input = {}
+        request = app.create_request(input).value
+        expect(request.span).to be_nil
+      end
+    end
+  end
 end

--- a/spec/salestation/web/error_mapper_spec.rb
+++ b/spec/salestation/web/error_mapper_spec.rb
@@ -12,7 +12,7 @@ describe Salestation::Web::ErrorMapper do
     end
 
     it 'returns custom error' do
-      response = Salestation::App::Request.new(env: {}, input: {}, initialize_hook: nil)
+      response = Salestation::App::Request.new(env: {}, input: {})
         .to_failure(custom_error_class.new)
         .map_err(&error_mapper.map)
         .value
@@ -26,7 +26,7 @@ describe Salestation::Web::ErrorMapper do
     let(:message) { 'no access' }
 
     it 'returns Responses::Forbidden' do
-      response = Salestation::App::Request.new(env: {}, input: {}, initialize_hook: nil)
+      response = Salestation::App::Request.new(env: {}, input: {})
         .to_failure(Salestation::App::Errors::Forbidden.new(message: message))
         .map_err(&error_mapper.map)
         .value
@@ -40,7 +40,7 @@ describe Salestation::Web::ErrorMapper do
 
     it 'throws UndefinedErrorClass exception' do
       expect {
-        Salestation::App::Request.new(env: {}, input: {}, initialize_hook: nil)
+        Salestation::App::Request.new(env: {}, input: {})
           .to_failure(StandardError.new)
           .map_err(&error_mapper.map)
       }.to raise_error(described_class::UndefinedErrorClass)


### PR DESCRIPTION
Makes integration with rack-tracer (OpenTracing lib) easier as we don't
have to put it in the input field where it could be overwritten.