### PR TITLE
Allow returning arrays as responses

### DIFF
--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -42,7 +42,7 @@ module Salestation
         constructor_type :strict
 
         attribute :status, Types::Strict::Int
-        attribute :body, Types::Strict::Hash
+        attribute :body, Types::Strict::Hash | Types::Strict::Array
       end
 
       class UnprocessableEntityFromSchemaErrors

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.3.0"
+  spec.version       = "0.4.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/salestation/web/responses/success_spec.rb
+++ b/spec/salestation/web/responses/success_spec.rb
@@ -5,17 +5,34 @@ describe Salestation::Web::Responses::Success do
 
   let(:attributes) { {status: status, body: body} }
   let(:status) { 200 }
-  let(:body) { {key: 'value'} }
 
-  it 'has status' do
-    expect(create_success.status).to eq(status)
+  context 'when body is a hash' do
+    let(:body) { {key: 'value'} }
+
+    it 'has status' do
+      expect(create_success.status).to eq(status)
+    end
+
+    it 'has body' do
+      expect(create_success.body).to eq(body)
+    end
   end
 
-  it 'has body' do
-    expect(create_success.body).to eq(body)
+  context 'when body is an array' do
+    let(:body) { [{foo: 'bar'}, {foo: 'baz'}] }
+
+    it 'has status' do
+      expect(create_success.status).to eq(status)
+    end
+
+    it 'has body' do
+      expect(create_success.body).to eq(body)
+    end
   end
 
   describe '.with_code' do
+    let(:body) { {key: 'value'} }
+
     it 'creates success with provided code' do
       expect(described_class.with_code(201).new(attributes).status)
         .to eq(201)


### PR DESCRIPTION
This is useful when an endpoint returns a list of objects.