### PR TITLE
Add message to Not Found error

### DIFF
--- a/lib/salestation/app/errors.rb
+++ b/lib/salestation/app/errors.rb
@@ -16,6 +16,8 @@ module Salestation
 
       class RequestedResourceNotFound < Dry::Struct
         constructor_type :strict
+
+        attribute :message, Types::Strict::String
       end
 
       class Forbidden < Dry::Struct

--- a/lib/salestation/web/error_mapper.rb
+++ b/lib/salestation/web/error_mapper.rb
@@ -14,7 +14,7 @@ module Salestation
           )
         },
         App::Errors::RequestedResourceNotFound => -> (error) {
-          Responses::NotFound.new(message: "Resource not found")
+          Responses::NotFound.new(message: error.message)
         },
         App::Errors::Forbidden => -> (error) {
           Responses::Forbidden.new(message: error.message)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.4.0"
+  spec.version       = "0.5.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 


### PR DESCRIPTION
It seems that `RequestedResourceNotFound ` is incorrectly used everywhere. In `enagement-registry` the error is created like this: https://github.com/salemove/engagement-registry/blob/master/lib/app/processors/active_record_fetcher.rb#L12 where these arguments (`errors` and `hints` are ignored). These should be changed with `InvalidInput` errors.

In `phone-number-manager` it's created like this: https://github.com/salemove/phone-number-manager/blob/master/lib/phone_number_manager/fetchers.rb#L11 where the message is also ignored.

Adding message to the error, to support custom messages e.g. "Site not found", "Phone number not found".
OM-134