### PR TITLE
Allow processing error responses

### DIFF
--- a/lib/salestation/app/errors.rb
+++ b/lib/salestation/app/errors.rb
@@ -2,54 +2,38 @@ module Salestation
   class App
     module Errors
       class InvalidInput < Dry::Struct
-        constructor_type :strict_with_defaults
-
         attribute :errors, Types::Strict::Hash
         attribute :hints, Types::Coercible::Hash.default({})
       end
 
       class DependencyCurrentlyUnavailable < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
       end
 
       class RequestedResourceNotFound < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
       end
 
       class Forbidden < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
       end
 
       class Conflict < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
       class NotAcceptable < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
       class UnsupportedMediaType < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
       class RequestEntityTooLarge < Dry::Struct
-        constructor_type :strict
-
         attribute :message, Types::Strict::String
       end
     end

--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -20,7 +20,12 @@ module Salestation
         const_set :Responses, Salestation::Web::Responses
 
         define_method(:process) do |response|
-          result = response.map_err(error_mapper.map).value
+          result =
+            if response.value.is_a?(Salestation::Web::Responses::Response)
+              response.value
+            else
+              response.map_err(error_mapper.map).value
+            end
 
           status result.status
           json result.body

--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -29,9 +29,8 @@ module Salestation
 
       class Error < Dry::Struct
         extend Response
-        constructor_type :strict_with_defaults
 
-        attribute :status, Types::Strict::Int
+        attribute :status, Types::Strict::Integer
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::String.default('')
         attribute :context, Types::Hash.default({})
@@ -43,9 +42,8 @@ module Salestation
 
       class Success < Dry::Struct
         extend Response
-        constructor_type :strict
 
-        attribute :status, Types::Strict::Int
+        attribute :status, Types::Strict::Integer
         attribute :body, Types::Strict::Hash | Types::Strict::Array
       end
 

--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -17,8 +17,8 @@ module Salestation
         -> (*) { Deterministic::Result::Success(Responses::NoContent.new(body: {})) }
       end
 
-      module Response
-        def with_code(code)
+      class Response < Dry::Struct
+        def self.with_code(code)
           Class.new(self) do
             define_singleton_method :new do |attrs|
               super(attrs.merge(status: code))
@@ -27,9 +27,7 @@ module Salestation
         end
       end
 
-      class Error < Dry::Struct
-        extend Response
-
+      class Error < Response
         attribute :status, Types::Strict::Integer
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::String.default('')
@@ -40,9 +38,7 @@ module Salestation
         end
       end
 
-      class Success < Dry::Struct
-        extend Response
-
+      class Success < Response
         attribute :status, Types::Strict::Integer
         attribute :body, Types::Strict::Hash | Types::Strict::Array
       end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.11.0"
+  spec.version       = "0.12.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/integration/salestation_spec.rb
+++ b/spec/integration/salestation_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'Salestation' do
+  it 'supports extracting input using Extractors module' do
+    web_app = Class.new do
+      include Salestation::Web.new
+      APP = Salestation::App.new(env: {})
+
+      def json(input)
+        input.to_json
+      end
+
+      def status(*); end
+
+      def create_app_request(input)
+        Salestation::App.new(env: {}).create_request(input)
+      end
+
+      def run
+        sinatra_request = Object.new
+        chain = ->(request) { Deterministic::Result::Success(request.input) }
+        extractor =
+          Salestation::Web::Extractors::ConstantInput[foo1: 'bar1']
+          .merge(Salestation::Web::Extractors::ConstantInput[foo2: 'bar2'])
+
+        process(
+          extractor.call(sinatra_request)
+            .map { |input| create_app_request(input) }
+            .map(chain)
+            .map(Salestation::Web::Responses.to_ok)
+        )
+      end
+    end
+
+    result = web_app.new.run
+    expect(result).to eq('{"foo1":"bar1","foo2":"bar2"}')
+  end
+
+  it 'shows input error when unable to extract input using an extractor' do
+    web_app = Class.new do
+      include Salestation::Web.new
+
+      def json(input)
+        input.to_json
+      end
+
+      def status(*); end
+
+      def create_app_request
+        lambda do |input|
+          Salestation::App.new(env: {}).create_request(input)
+        end
+      end
+
+      def run
+        sinatra_request = Object.new
+        chain = ->(request) { Deterministic::Result::Success(request.input) }
+        extractor = lambda do |_request|
+          Deterministic::Result::Failure(
+            Salestation::Web::Responses::Unauthorized.new(message: 'unauthorized')
+          )
+        end
+
+        process(
+          extractor.call(sinatra_request)
+            .map(create_app_request)
+            .map(chain)
+            .map(Salestation::Web::Responses.to_ok)
+        )
+      end
+    end
+
+    result = web_app.new.run
+    expect(result).to eq('{"message":"unauthorized","debug_message":""}')
+  end
+end


### PR DESCRIPTION
Previously it was not possible to use #process on a
`Failure(Salestation::Web::Responses::Error)` object. This meant that we
first had to map Failure into Success before calling process. This produced
code like:

```ruby def process(extract_input, &process_request)
 response = extract_input.call(request).match do
   Success() do |value|
     # regular flow
   end
   Failure() do |value|
     # change input error to Success to render correctly
     Result::Success(value)
   end
 end end
```

This is now not necessary. '#process` method now checks the result type and
handles Salestation::Web::Responses::Response instances correctly.

This commit also added couple of integration tests to ensure it works and
simplified the example in the README.