### PR TITLE
Add support for custom headers in web app responses

### DIFF
--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -28,6 +28,7 @@ module Salestation
             end
 
           status result.status
+          headers result.headers
           json result.body
         end
       end

--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -32,6 +32,7 @@ module Salestation
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::String.default('')
         attribute :context, Types::Hash.default({})
+        attribute :headers, Types::Hash.default({})
 
         def body
           {message: message, debug_message: debug_message}
@@ -41,6 +42,7 @@ module Salestation
       class Success < Response
         attribute :status, Types::Strict::Integer
         attribute :body, Types::Strict::Hash | Types::Strict::Array
+        attribute :headers, Types::Hash.default({})
       end
 
       class UnprocessableEntityFromSchemaErrors

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.12.0"
+  spec.version       = "0.13.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/integration/failure_handling_spec.rb
+++ b/spec/integration/failure_handling_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe 'Failure handling' do
   let(:custom_error_class) { Class.new(StandardError) }
-  let(:custom_error_response) { double(body: custom_response, status: 200) }
+  let(:custom_error_response) { double(body: custom_response, status: 200, headers: headers) }
   let(:custom_response) { {custom: 'response'} }
+  let(:headers) { {'X-Custom-Header' => 'Value'} }
 
   before do
     stub_const('CustomErrorClass', custom_error_class)
@@ -27,11 +28,17 @@ describe 'Failure handling' do
         process(chain.call(app.create_request({})))
       end
 
-      def status(*)
-      end
+      def status(*); end
+
+      def headers(*); end
     end
 
-    response = web_app.new.run
+    app = web_app.new
+    allow(app).to receive(:headers)
+
+    response = app.run
     expect(response).to eq(JSON.dump(custom_response))
+
+    expect(app).to have_received(:headers).with(headers)
   end
 end

--- a/spec/integration/salestation_spec.rb
+++ b/spec/integration/salestation_spec.rb
@@ -12,6 +12,8 @@ describe 'Salestation' do
 
       def status(*); end
 
+      def headers(*); end
+
       def create_app_request(input)
         Salestation::App.new(env: {}).create_request(input)
       end
@@ -45,6 +47,8 @@ describe 'Salestation' do
       end
 
       def status(*); end
+
+      def headers(*); end
 
       def create_app_request
         lambda do |input|

--- a/spec/salestation/web/responses/error_spec.rb
+++ b/spec/salestation/web/responses/error_spec.rb
@@ -4,16 +4,20 @@ describe Salestation::Web::Responses::Error do
   subject(:create_error) { described_class.new(attributes) }
   let(:attributes) { all_attributes }
 
-  let(:all_attributes) { {
-    status: status,
-    message: message,
-    debug_message: debug_message,
-    context: context
-  } }
+  let(:all_attributes) do
+    {
+      status: status,
+      message: message,
+      debug_message: debug_message,
+      context: context,
+      headers: headers
+    }
+  end
   let(:status) { 200 }
   let(:message) { 'message' }
   let(:debug_message) { 'debug message' }
   let(:context) { {foo: 'bar'} }
+  let(:headers) { {'X-Custom-Header' => 'Value'} }
 
   it 'has status' do
     expect(create_error.status).to eq(status)
@@ -35,6 +39,10 @@ describe Salestation::Web::Responses::Error do
     expect(create_error.body).to eql(message: message, debug_message: debug_message)
   end
 
+  it 'has headers' do
+    expect(create_error.headers).to eq(headers)
+  end
+
   context 'when debug message is missing' do
     let(:attributes) { all_attributes.except(:debug_message) }
 
@@ -48,6 +56,14 @@ describe Salestation::Web::Responses::Error do
 
     it 'defaults to empty hash' do
       expect(create_error.context).to eq({})
+    end
+  end
+
+  context 'when headers are missing' do
+    let(:attributes) { all_attributes.except(:headers) }
+
+    it 'defaults to empty hash' do
+      expect(create_error.headers).to eq({})
     end
   end
 

--- a/spec/salestation/web/responses/success_spec.rb
+++ b/spec/salestation/web/responses/success_spec.rb
@@ -3,8 +3,9 @@ require 'spec_helper'
 describe Salestation::Web::Responses::Success do
   subject(:create_success) { described_class.new(attributes) }
 
-  let(:attributes) { {status: status, body: body} }
+  let(:attributes) { {status: status, body: body, headers: headers} }
   let(:status) { 200 }
+  let(:headers) { {'X-Custom-Header' => 'Value'} }
 
   context 'when body is a hash' do
     let(:body) { {key: 'value'} }
@@ -15,6 +16,10 @@ describe Salestation::Web::Responses::Success do
 
     it 'has body' do
       expect(create_success.body).to eq(body)
+    end
+
+    it 'has headers' do
+      expect(create_success.headers).to eq(headers)
     end
   end
 
@@ -27,6 +32,10 @@ describe Salestation::Web::Responses::Success do
 
     it 'has body' do
       expect(create_success.body).to eq(body)
+    end
+
+    it 'has headers' do
+      expect(create_success.headers).to eq(headers)
     end
   end
 

--- a/spec/salestation/web_spec.rb
+++ b/spec/salestation/web_spec.rb
@@ -8,8 +8,9 @@ describe Salestation::Web do
       input.to_json
     end
 
-    def status(*)
-    end
+    def status(*); end
+
+    def headers(*); end
   end
 
   let(:web_app) { WebApp.new }


### PR DESCRIPTION
Previously it was hard to set up custom headers set in the response.
This change makes it more convenient.