### PR TITLE
Add nested input key whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ def create_app_request
 end
 
 post '/hello/:name' do |name|
-  coercions = {age: ->(age) { age.to_s }}
-
-  extractor = BodyParamExtractor[:age, coercions: coercions]
+  extractor = BodyParamExtractor[:age]
     .merge(ConstantInput[name: name])
     .merge(HeadersExtractor[{'authorization' => :auth}])
+    .coerce(age: ->(age) { age.to_s })
 
   response = extractor.call(request)
     .map(create_app_request)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "0.13.0"
+  spec.version       = "1.0.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/integration/salestation_spec.rb
+++ b/spec/integration/salestation_spec.rb
@@ -23,7 +23,8 @@ describe 'Salestation' do
         chain = ->(request) { Deterministic::Result::Success(request.input) }
         extractor =
           Salestation::Web::Extractors::ConstantInput[foo1: 'bar1']
-          .merge(Salestation::Web::Extractors::ConstantInput[foo2: 'bar2'])
+          .merge(Salestation::Web::Extractors::ConstantInput[foo2: 'bar_2'])
+          .coerce(foo2: ->(_value) { 'bar2' })
 
         process(
           extractor.call(sinatra_request)

--- a/spec/salestation/web/extractors/query_param_extractor_spec.rb
+++ b/spec/salestation/web/extractors/query_param_extractor_spec.rb
@@ -51,30 +51,4 @@ describe Salestation::Web::Extractors::QueryParamExtractor do
       expect(result.value).to eq(expected_result)
     end
   end
-
-  context 'with coercions' do
-    let(:params) do
-      {
-        'first_key' => 'first value',
-        'second_key' => 'second value'
-      }
-    end
-
-    let(:expected_result) do
-      {
-        first_key: 'new first value',
-        second_key: 'second value'
-      }
-    end
-
-    let(:coercions) { {first_key: ->(first_key) { 'new ' + first_key }} }
-    let(:options) { [:first_key, :second_key, {coercions: coercions}] }
-
-    it 'coerces param' do
-      result = extract_query_params
-
-      expect(result).to be_a(Deterministic::Result::Success)
-      expect(result.value).to eq(expected_result)
-    end
-  end
 end


### PR DESCRIPTION
Previously it was not possible to whitelist nested keys. Whitelisting
`:foo` returned `{foo: {'bar' => 'baz'}}` when the input was `{'foo' =>
{'bar' => 'baz'}`. Now it's possible to whitelisted nested keys as well.

Example:
```
 extractor = BodyParamExtractor[:x, :y, {foo: [:bar, :baz]}]
```

This however didn't work well with coercions. Coercions are now extracted
to a separate function instead of coercing immediately in the
BodyParamExtractor / etc extractor. This also means than now we can coerce
all kind of inputs, even ConstantInput.