### PR TITLE
Change log_response_body default value to false

### DIFF
--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -16,7 +16,7 @@ module Salestation
       SERVER_NAME = 'SERVER_NAME'
       JSON_CONTENT_TYPE = 'application/json'
 
-      def initialize(app, logger, log_response_body: true)
+      def initialize(app, logger, log_response_body: false)
         @app = app
         @logger = logger
         @log_response_body = log_response_body

--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
 require 'json'
 
 module Salestation

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "2.0.0"
+  spec.version       = "3.0.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/salestation/web/request_logger_spec.rb
+++ b/spec/salestation/web/request_logger_spec.rb
@@ -15,16 +15,16 @@ describe Salestation::Web::RequestLogger do
   end
 
   describe '#call' do
-    it 'logs response body' do
+    it 'logs response body when response body logging is enabled' do
       expect(logger).to receive(:info).with(
         'Processed request',
         a_hash_including(body: { 'key' => 'value' })
       )
-      described_class.new(web_app, logger).call({})
+      described_class.new(web_app, logger, log_response_body: true).call({})
     end
 
     it 'does not log response body when response body logging is disabled' do
-      described_class.new(web_app, logger, log_response_body: false).call({})
+      described_class.new(web_app, logger).call({})
 
       expect(logger).to have_received(:info).with(
         'Processed request',


### PR DESCRIPTION
Response body can be complex object of unknown size. This can negatively 
affect performance. I observed a performance gain in a service from
~600req/s to ~680req/s by just changing this. That's about 10% improvement.

Avoid logging out the reponse body and rely on explicit logging in 
conjunction with a log containing the response status and headers.