### PR TITLE
Improve logging middleware

### DIFF
--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module Salestation
   class Web < Module
     class RequestLogger
@@ -49,25 +47,12 @@ module Salestation
         }
 
         if status >= 400
-          log[:error] = parse_body(body)
+          log[:error] = body.join
         elsif @log_response_body
-          log[:body] = parse_body(body)
+          log[:body] = body.join
         end
 
         log
-      end
-
-      def parse_body(body)
-        # Rack body is an array
-        return {} if body.empty?
-
-        if defined?(Oj)
-          Oj.load(body.join)
-        else
-          JSON.parse(body.join)
-        end
-      rescue Exception
-        {error: 'Failed to parse response body'}
       end
     end
   end

--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -12,7 +12,6 @@ module Salestation
       HTTP_USER_AGENT = 'HTTP_USER_AGENT'
       HTTP_ACCEPT = 'HTTP_ACCEPT'
       SERVER_NAME = 'SERVER_NAME'
-      JSON_CONTENT_TYPE = 'application/json'
 
       def initialize(app, logger, log_response_body: false)
         @app = app

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.2.1"
+  spec.version       = "3.2.2"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/spec/salestation/web/request_logger_spec.rb
+++ b/spec/salestation/web/request_logger_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 describe Salestation::Web::RequestLogger do
   class Webapp
     def call(env)
-      [200, {}, [{ 'key' => 'value' }.to_json]]
+      status = env.fetch(:status, 200)
+      body = env.fetch(:body, '')
+      headers = env.fetch(:headers, {})
+
+      [status, headers, [body]]
     end
   end
 
@@ -15,21 +19,54 @@ describe Salestation::Web::RequestLogger do
   end
 
   describe '#call' do
-    it 'logs response body when response body logging is enabled' do
-      expect(logger).to receive(:info).with(
-        'Processed request',
-        a_hash_including(body: { 'key' => 'value' })
-      )
-      described_class.new(web_app, logger, log_response_body: true).call({})
+    context 'when response body logging is enabled' do
+      let(:middleware) { described_class.new(web_app, logger, log_response_body: true) }
+
+      it 'logs response body' do
+        response = { 'key' => 'value' }.to_json
+
+        expect(logger).to receive(:info).with(
+          'Processed request',
+          a_hash_including(body: response)
+        )
+
+        middleware.call(body: response)
+      end
     end
 
-    it 'does not log response body when response body logging is disabled' do
-      described_class.new(web_app, logger).call({})
+    context 'when response body logging is disabled' do
+      let(:middleware) { described_class.new(web_app, logger) }
 
-      expect(logger).to have_received(:info).with(
-        'Processed request',
-        hash_excluding(body: anything)
-      )
+      it 'does not log response body' do
+        expect(logger).to receive(:info).with(
+          'Processed request',
+          hash_excluding(body: anything)
+        )
+
+        middleware.call({})
+      end
+
+      it 'logs response body as ERROR when response status is >= 500' do
+        error = 'Service unavailable'
+
+        expect(logger).to receive(:error).with(
+          'Processed request',
+          a_hash_including(error: error)
+        )
+
+        middleware.call(status: 503, body: error)
+      end
+
+      it 'logs response body as INFO when response status is >= 400' do
+        error = 'Bad request'
+
+        expect(logger).to receive(:info).with(
+          'Processed request',
+          a_hash_including(error: error)
+        )
+
+        middleware.call(status: 400, body: error)
+      end
     end
   end
 end


### PR DESCRIPTION
# Log response body as a string, not an object

Previously, `RequestLogger` middleware attempted to parse response body
always, even if it wasn't valid JSON. This resulted in noisy and
misleading log messages "Failed to parse response body" in case of, for
instance, errors 403 returned by `Rack::CORS` middleware.

Since `log_response_body` setting is disabled by default anyway, logging
body as an object is probably an overkill and logging it as a plain
string would be sufficient for most of the cases.

---

# Use monotonic time to measure request duration

Wall-clock time shouldn't be used for measuring duration, because it may
change for many reasons, e.g. changing the system time can affect the
results or a leap second will disrupt the result. In some cases, time
can move backwards if the server uses NTP.

There is more info in the [article][1], explaining why wall-clock time
can't be used for measuring duration and why monotonic clock should be
used instead.

[1]: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/