### PR TITLE
Allow specifying log level for RequestLogger

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Indrek Juhkam
+Copyright (c) 2016 Glia Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.2.2"
+  spec.version       = "3.3.0"
   spec.authors       = ["SaleMove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -5,8 +5,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
   spec.version       = "3.3.0"
-  spec.authors       = ["SaleMove TechMovers"]
-  spec.email         = ["techmovers@salemove.com"]
+  spec.authors       = ["Glia TechMovers"]
+  spec.email         = ["techmovers@glia.com"]
 
   spec.summary       = %q{}
   spec.description   = %q{}

--- a/spec/salestation/web/request_logger_spec.rb
+++ b/spec/salestation/web/request_logger_spec.rb
@@ -34,6 +34,37 @@ describe Salestation::Web::RequestLogger do
       end
     end
 
+    context 'when log level is set to debug' do
+      let(:middleware) { described_class.new(web_app, logger, level: :debug) }
+
+      it 'logs messages with debug level' do
+        expect(logger).to receive(:debug).with(
+          'Processed request',
+          an_instance_of(Hash)
+        )
+
+        middleware.call({})
+      end
+
+      it 'logs requests with status code 4xx as info' do
+        expect(logger).to receive(:info).with(
+          'Processed request',
+          an_instance_of(Hash)
+        )
+
+        middleware.call(status: 404)
+      end
+
+      it 'logs requests with status code 5xx as error' do
+        expect(logger).to receive(:error).with(
+          'Processed request',
+          an_instance_of(Hash)
+        )
+
+        middleware.call(status: 500)
+      end
+    end
+
     context 'when response body logging is disabled' do
       let(:middleware) { described_class.new(web_app, logger) }
 


### PR DESCRIPTION
Useful for example when we want to log requests with debug level.