### PR TITLE
Add extractor for extracting everything from request body

### DIFF
--- a/lib/salestation/web/extractors.rb
+++ b/lib/salestation/web/extractors.rb
@@ -166,6 +166,28 @@ module Salestation
           end
         end
       end
+
+      # Extracts all parameters from request body without symbolizing the keys.
+      #
+      # @example
+      #  extractor = BodyExtractor[to: :custom_attributes]
+      #  input = {
+      #   'x' => '1',
+      #   'y' => '2'
+      #  }
+      #  # rack_request is Rack::Request with 'rack.request.form_hash' set to input
+      #  extractor.call(rack_request).value #=>
+      #    {custom_attributes: {'x' => '1', 'y' => '2'}}
+      #
+      class BodyExtractor
+        include Deterministic
+
+        def self.[](to:)
+          InputExtractor.new do |rack_request|
+            Result::Success(to => rack_request.env['rack.request.form_hash'])
+          end
+        end
+      end
     end
   end
 end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.3.0"
+  spec.version       = "3.3.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
This is needed in visitor-information to extract all custom attributes
from request body. Note that we do not have to atomize the keys because
we do not have to access any of the custom attributes explicitly.

CHAN-244