### PR TITLE
Allow coerced input to be merged with further extraction

### DIFF
--- a/lib/salestation/web/extractors.rb
+++ b/lib/salestation/web/extractors.rb
@@ -82,6 +82,10 @@ module Salestation
           end
           Deterministic::Result::Success(input)
         end
+
+        def merge(other)
+          CombinedInputExtractor.new([self, other])
+        end
       end
 
       class HeadersExtractor

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.3.0"
+  spec.version       = "3.4.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Helpful when there is a reusable header extractor that is appended to an
input extractor that performs coercion.