### PR TITLE
Allow per-request tags for statsd

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ class Webapp < Sinatra::Base
 end
 ```
 
+You can configure per-request tags by defining `salestation.statsd.tags` in sinatra `env`:
+
+```ruby
+  def my_handler(env)
+    env['salestation.statsd.tags'] = ['foo', 'bar']
+    # ...
+  end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/salestation/web/statsd_middleware.rb
+++ b/lib/salestation/web/statsd_middleware.rb
@@ -3,6 +3,7 @@
 module Salestation
   class Web < Module
     class StatsdMiddleware
+      EXTRA_TAGS_ENV_KEY = 'salestation.statsd.tags'
 
       def initialize(app, statsd, metric:)
         @app = app
@@ -23,11 +24,13 @@ module Salestation
             'unknown-route'
           end
 
-        @statsd.timing(@metric, (Time.now - start) * 1000, tags: [
+        tags = [
           "path:#{ path }",
           "method:#{ method }",
           "status:#{ status }"
-        ])
+        ] + env.fetch(EXTRA_TAGS_ENV_KEY, [])
+
+        @statsd.timing(@metric, (Time.now - start) * 1000, tags: tags)
 
         [status, header, body]
       end

--- a/lib/salestation/web/statsd_middleware.rb
+++ b/lib/salestation/web/statsd_middleware.rb
@@ -5,6 +5,8 @@ module Salestation
     class StatsdMiddleware
       EXTRA_TAGS_ENV_KEY = 'salestation.statsd.tags'
 
+      DURATION_PRECISION = 6
+
       def initialize(app, statsd, metric:)
         @app = app
         @statsd = statsd
@@ -12,7 +14,7 @@ module Salestation
       end
 
       def call(env)
-        start = Time.now
+        start = system_monotonic_time
 
         status, header, body = @app.call env
 
@@ -30,9 +32,19 @@ module Salestation
           "status:#{ status }"
         ] + env.fetch(EXTRA_TAGS_ENV_KEY, [])
 
-        @statsd.timing(@metric, (Time.now - start) * 1000, tags: tags)
+        @statsd.timing(@metric, duration(from: start), tags: tags)
 
         [status, header, body]
+      end
+
+      private
+
+      def duration(from:)
+        (system_monotonic_time - from).round(DURATION_PRECISION)
+      end
+
+      def system_monotonic_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
   end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10.4"
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.4.0"
+  spec.version       = "3.5.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Helps to differentiate kinds of requests in metrics (reporting,
read-only, maintenance, etc).