### PR TITLE
Fix response time metric unit

### DIFF
--- a/lib/salestation/web/statsd_middleware.rb
+++ b/lib/salestation/web/statsd_middleware.rb
@@ -5,7 +5,7 @@ module Salestation
     class StatsdMiddleware
       EXTRA_TAGS_ENV_KEY = 'salestation.statsd.tags'
 
-      DURATION_PRECISION = 6
+      DURATION_MILLISECOND_PRECISION = 3
 
       def initialize(app, statsd, metric:)
         @app = app
@@ -32,15 +32,15 @@ module Salestation
           "status:#{ status }"
         ] + env.fetch(EXTRA_TAGS_ENV_KEY, [])
 
-        @statsd.timing(@metric, duration(from: start), tags: tags)
+        @statsd.timing(@metric, duration_ms(from: start), tags: tags)
 
         [status, header, body]
       end
 
       private
 
-      def duration(from:)
-        (system_monotonic_time - from).round(DURATION_PRECISION)
+      def duration_ms(from:)
+        ((system_monotonic_time - from) * 1000).round(DURATION_MILLISECOND_PRECISION)
       end
 
       def system_monotonic_time

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.5.0"
+  spec.version       = "3.5.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Supported statsd libraries (namely dogstatsd-ruby) in StatsdMiddleware
accept timings in milliseconds. 3afdf83 changed the way that response
times are calculated but mistakenly started providing values in seconds.