### PR TITLE
Add status_class tag to StatsdMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,14 @@ end
 
 Salestation provides a StatsD middleware which can be used record request
 execution time. A `timing` call with elapsed seconds is made to the provided
-StatsD instance with `path`, `method`, `status` tags.
+StatsD instance with `path`, `method`, `status` and `status_class` tags.
 
 ```ruby
 class Webapp < Sinatra::Base
   # ...
   use Salestation::Web::StatsdMiddleware,
     Statsd.new(host, port),
-    metric: 'my-metric'
+    metric: 'my_service.response.time'
 end
 ```
 
@@ -157,7 +157,7 @@ You can configure per-request tags by defining `salestation.statsd.tags` in sina
 
 ```ruby
   def my_handler(env)
-    env['salestation.statsd.tags'] = ['foo', 'bar']
+    env['salestation.statsd.tags'] = ['foo:bar']
     # ...
   end
 ```

--- a/lib/salestation/web/statsd_middleware.rb
+++ b/lib/salestation/web/statsd_middleware.rb
@@ -27,9 +27,10 @@ module Salestation
           end
 
         tags = [
-          "path:#{ path }",
-          "method:#{ method }",
-          "status:#{ status }"
+          "path:#{path}",
+          "method:#{method}",
+          "status:#{status}",
+          "status_class:#{status / 100}xx"
         ] + env.fetch(EXTRA_TAGS_ENV_KEY, [])
 
         @statsd.timing(@metric, duration_ms(from: start), tags: tags)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.6.0"
+  spec.version       = "3.7.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/statsd_middleware_spec.rb
+++ b/spec/salestation/web/statsd_middleware_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Salestation::Web::StatsdMiddleware do
+  class Webapp
+    def call(env)
+      status = env.fetch(:status, 200)
+      body = env.fetch(:body, '')
+      headers = env.fetch(:headers, {})
+
+      [status, headers, [body]]
+    end
+  end
+
+  let(:web_app) { Webapp.new }
+  let(:statsd) { double }
+
+  describe '#call' do
+    it 'records status and status class' do
+      middleware = described_class.new(web_app, statsd, metric: 'test.req')
+
+      expect(statsd).to receive(:timing)
+        .with(
+          'test.req',
+          instance_of(Float),
+          tags: include('status:204', 'status_class:2xx')
+        )
+
+      middleware.call(status: 204)
+    end
+  end
+end


### PR DESCRIPTION
Makes it easier to create monitors for the whole status class (e.g. alter
when 5xx errors, or exclude 2xx).