### PR TITLE
Return error hash for invalid input error

### DIFF
--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -41,6 +41,14 @@ module Salestation
         end
       end
 
+      class UnprocessableEntityError < Error
+        attribute :form_errors, Types::Hash.default({}.freeze)
+
+        def body
+          super.merge(form_errors: errors)
+        end
+      end
+
       class Success < Response
         attribute :status, Types::Strict::Integer
         attribute :body, Types::Strict::Hash | Types::Strict::Array
@@ -52,7 +60,7 @@ module Salestation
           message = parse_errors(errors)
           debug_message = parse_hints(hints)
 
-          UnprocessableEntity.new(message: message, debug_message: debug_message)
+          UnprocessableEntity.new(message: message, debug_message: debug_message, form_errors: errors)
         end
 
         def self.parse_errors(errors)
@@ -99,7 +107,7 @@ module Salestation
       Conflict = Error.with_code(409)
       RequestEntityTooLarge = Error.with_code(413)
       UnsupportedMediaType = Error.with_code(415)
-      UnprocessableEntity = Error.with_code(422)
+      UnprocessableEntity = UnprocessableEntityError.with_code(422)
 
       InternalError = Error.with_code(500)
       ServiceUnavailable = Error.with_code(503)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.7.0"
+  spec.version       = "3.8.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
+++ b/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
@@ -21,6 +21,10 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
     it 'parses error debug message' do
       expect(error.debug_message).to eq("'content' is missing")
     end
+
+    it 'returns error hash' do
+      expect(error.form_errors).to eq(errors)
+    end
   end
 
   context 'error with multiple messages' do
@@ -33,6 +37,10 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
 
     it 'parses error debug message' do
       expect(error.debug_message).to eq("'content' is missing and is invalid")
+    end
+
+    it 'returns error hash' do
+      expect(error.form_errors).to eq(errors)
     end
   end
 
@@ -68,6 +76,10 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
       expect(error.debug_message).to eq(
         "'status' is missing and is invalid. 'message.id' is missing. 'message.content' is invalid. 'context' is invalid"
       )
+    end
+
+    it 'returns error hash' do
+      expect(error.form_errors).to eq(errors)
     end
   end
 end


### PR DESCRIPTION
This change allows FE to highlight erronous fields without much effort and
should be generaly good improvement for UX

Bump minor version