### PR TITLE
Allow to pass custom data to error responses 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,28 @@ Salestation allows and recommends you to define your own custom errors. This is 
   })
 ```
 
+### Providing custom error fields
+
+If you need to specify additional error fields you can use `from` method.
+`from` accepts base error on which the rest of the response is built.
+Base error must be a hash or implement `to_h` method.
+
+Example:
+
+```
+App::Errors::Conflict.from({details: 'details'}, message: 'message', debug_message: 'debug_message')
+```
+
+Response:
+
+```javascript
+{
+  "details": "details",
+  "message": "message",
+  "debug_message": "debug_message"
+}
+```
+
 ### Using Extractors
 
 Salestation provides extractors to fetch parameters from the request and pass them to the chain.

--- a/lib/salestation/app/errors.rb
+++ b/lib/salestation/app/errors.rb
@@ -3,43 +3,51 @@
 module Salestation
   class App
     module Errors
-      class InvalidInput < Dry::Struct
+      class Error < Dry::Struct
+        attribute? :base_error, Types::Coercible::Hash
+
+        def self.from(base_error, overrides = {})
+          new(**overrides, base_error: base_error.to_h)
+        end
+      end
+
+      class InvalidInput < Error
         attribute :errors, Types::Strict::Hash
         attribute :hints, Types::Coercible::Hash.default({}.freeze)
         attribute? :debug_message, Types::Strict::String
       end
 
-      class DependencyCurrentlyUnavailable < Dry::Struct
+      class DependencyCurrentlyUnavailable < Error
         attribute :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
-      class RequestedResourceNotFound < Dry::Struct
+      class RequestedResourceNotFound < Error
         attribute :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
-      class Forbidden < Dry::Struct
+      class Forbidden < Error
         attribute :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
-      class Conflict < Dry::Struct
+      class Conflict < Error
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
-      class NotAcceptable < Dry::Struct
+      class NotAcceptable < Error
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
-      class UnsupportedMediaType < Dry::Struct
+      class UnsupportedMediaType < Error
         attribute :message, Types::Strict::String
         attribute :debug_message, Types::Strict::String
       end
 
-      class RequestEntityTooLarge < Dry::Struct
+      class RequestEntityTooLarge < Error
         attribute :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end

--- a/lib/salestation/web/error_mapper.rb
+++ b/lib/salestation/web/error_mapper.rb
@@ -12,26 +12,27 @@ module Salestation
         App::Errors::DependencyCurrentlyUnavailable => -> (error) {
           Responses::ServiceUnavailable.new(
             message: error.message,
-            debug_message: "Please try again later"
+            debug_message: "Please try again later",
+            base_error: error.base_error
           )
         },
         App::Errors::RequestedResourceNotFound => -> (error) {
-          Responses::NotFound.new(message: error.message, debug_message: error.debug_message)
+          Responses::NotFound.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         },
         App::Errors::Forbidden => -> (error) {
-          Responses::Forbidden.new(message: error.message, debug_message: error.debug_message)
+          Responses::Forbidden.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         },
         App::Errors::Conflict => -> (error) {
-          Responses::Conflict.new(message: error.message, debug_message: error.debug_message)
+          Responses::Conflict.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         },
         App::Errors::NotAcceptable => -> (error) {
-          Responses::NotAcceptable.new(message: error.message, debug_message: error.debug_message)
+          Responses::NotAcceptable.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         },
         App::Errors::UnsupportedMediaType => -> (error) {
-          Responses::UnsupportedMediaType.new(message: error.message, debug_message: error.debug_message)
+          Responses::UnsupportedMediaType.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         },
         App::Errors::RequestEntityTooLarge => -> (error) {
-          Responses::RequestEntityTooLarge.new(message: error.message, debug_message: error.debug_message)
+          Responses::RequestEntityTooLarge.new(message: error.message, debug_message: error.debug_message, base_error: error.base_error)
         }
       }.freeze
 

--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -35,9 +35,11 @@ module Salestation
         attribute :debug_message, Types::Coercible::String.default('')
         attribute :context, Types::Hash.default({}.freeze)
         attribute :headers, Types::Hash.default({}.freeze)
+        attribute? :base_error, Types::Coercible::Hash
 
         def body
-          {message: message, debug_message: debug_message}
+          # Merge into `base_error` to ensure standard fields are not overriden
+          (base_error || {}).merge(message: message, debug_message: debug_message)
         end
       end
 
@@ -56,11 +58,11 @@ module Salestation
       end
 
       class UnprocessableEntityFromSchemaErrors
-        def self.create(errors:, hints:)
+        def self.create(errors:, hints:, base_error: nil)
           message = parse_errors(errors)
           debug_message = parse_hints(hints)
 
-          UnprocessableEntity.new(message: message, debug_message: debug_message, form_errors: errors)
+          UnprocessableEntity.new(message: message, debug_message: debug_message, form_errors: errors, base_error: base_error)
         end
 
         def self.parse_errors(errors)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.8.1"
+  spec.version       = "3.9.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/app/errors/invalid_input_spec.rb
+++ b/spec/salestation/app/errors/invalid_input_spec.rb
@@ -23,4 +23,29 @@ describe Salestation::App::Errors::InvalidInput do
       expect(create_invalid_input.hints).to eq({})
     end
   end
+
+  context '.from' do
+    let(:base_error) { {details: 'details'} }
+
+    it 'creates error with base error, errors and hints' do
+       invalid_input = described_class.from(base_error, errors: errors, hints: hints)
+
+       expect(invalid_input.errors).to eql(errors)
+       expect(invalid_input.hints).to eql(hints)
+       expect(invalid_input.base_error).to eql(base_error)
+    end
+
+    context 'when base error is not hash' do
+      class BaseError
+        def to_h
+          {details: 'details2'}
+        end
+      end
+
+      it 'converts base error to hash' do
+        invalid_input = described_class.from(BaseError.new, errors: errors, hints: hints)
+        expect(invalid_input.base_error).to eql(BaseError.new.to_h)
+      end
+    end
+  end
 end

--- a/spec/salestation/web/responses/error_spec.rb
+++ b/spec/salestation/web/responses/error_spec.rb
@@ -10,13 +10,15 @@ describe Salestation::Web::Responses::Error do
       message: message,
       debug_message: debug_message,
       context: context,
-      headers: headers
+      headers: headers,
+      base_error: base_error
     }
   end
   let(:status) { 200 }
   let(:message) { 'message' }
   let(:debug_message) { 'debug message' }
   let(:context) { {foo: 'bar'} }
+  let(:base_error) { {info: 'info'} }
   let(:headers) { {'X-Custom-Header' => 'Value'} }
 
   it 'has status' do
@@ -35,12 +37,24 @@ describe Salestation::Web::Responses::Error do
     expect(create_error.context).to eq(context)
   end
 
-  it 'has message and debug_message in body' do
-    expect(create_error.body).to eql(message: message, debug_message: debug_message)
+  it 'has message, debug_message and merged base_error info in body' do
+    expect(create_error.body).to eql(message: message, debug_message: debug_message, info: base_error[:info])
   end
 
   it 'has headers' do
     expect(create_error.headers).to eq(headers)
+  end
+
+  it 'has base_error info' do
+    expect(create_error.base_error).to eq(base_error)
+  end
+
+  context 'when base_error contains message and debug_message' do
+    let(:base_error) { {message: 'message_override', debug_message: 'debug_message_override'} }
+
+    it 'does not override message and debug_message with values from base_error' do
+      expect(create_error.body).to eql(message: message, debug_message: debug_message)
+    end
   end
 
   context 'when debug message is missing' do

--- a/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
+++ b/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
@@ -83,4 +83,19 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
       expect(error.form_errors).to eq(errors)
     end
   end
+
+  context 'with base error information' do
+    let(:attributes) { {
+      errors: errors,
+      hints: hints,
+      base_error: base_error
+    } }
+    let(:base_error) { {info: 'info'} }
+    let(:errors) { {content: ['is missing', 'is invalid']} }
+    let(:hints) { {content: ['is missing', 'is invalid']} }
+
+    it 'parses error debug message' do
+      expect(error.base_error).to eq(base_error)
+    end
+  end
 end


### PR DESCRIPTION
We are in the process of the migration to new error structure which will
contain new fields such as `type`, `ref` and `error_details` and need to
be able to return pass this to salestation and include in the error
response.

CHAN-1403