### PR TITLE
Disable form errors

### DIFF
--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -44,10 +44,10 @@ module Salestation
       end
 
       class UnprocessableEntityError < Error
-        attribute :form_errors, Types::Hash.default({}.freeze)
+        attribute? :form_errors, Types::Coercible::Hash.optional
 
         def body
-          super.merge(form_errors: form_errors)
+          super.merge({form_errors: form_errors}.compact)
         end
       end
 
@@ -58,11 +58,16 @@ module Salestation
       end
 
       class UnprocessableEntityFromSchemaErrors
-        def self.create(errors:, hints:, base_error: nil)
+        def self.create(errors:, hints:, base_error: nil, form_errors: false)
           message = parse_errors(errors)
           debug_message = parse_hints(hints)
 
-          UnprocessableEntity.new(message: message, debug_message: debug_message, form_errors: errors, base_error: base_error)
+          UnprocessableEntity.new(
+            message: message,
+            debug_message: debug_message,
+            form_errors: form_errors ? errors : nil,
+            base_error: base_error
+          )
         end
 
         def self.parse_errors(errors)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "3.9.0"
+  spec.version       = "4.0.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
+++ b/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
@@ -5,6 +5,7 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
   let(:attributes) { {
     errors: errors,
     hints: hints,
+    form_errors: true
   } }
 
   let(:errors) { {} }
@@ -96,6 +97,17 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
 
     it 'parses error debug message' do
       expect(error.base_error).to eq(base_error)
+    end
+  end
+
+  context 'without enabling form errors' do
+    let(:attributes) { {
+      errors: {content: ['is missing', 'is invalid']},
+      hints: {content: ['is missing', 'is invalid']}
+    } }
+
+    it 'does not include form errors' do
+      expect(error.body.key?(:form_errors)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
`form_errors` were added to have a breakdown or errors per field.
However, we now also provide a way to specify any custom field plus we
have a new Glia errors format, which makes `form_errors` obsolete.

In addition migration to Glia errors will require updating salestation to the latest
version and we want to avoid polution error responses with `form_errors`.

For backward compatibility there is an option to keep `form_errors`
enabled.

CHAN-1403