### PR TITLE
Fix parameter extraction when nested parameter is `nil`

### DIFF
--- a/lib/salestation/web/extractors.rb
+++ b/lib/salestation/web/extractors.rb
@@ -125,8 +125,10 @@ module Salestation
               extracted_data[filter] = request_hash[stringified_key] if request_hash.key?(stringified_key)
             when Hash
               filter.each do |key, nested_filters|
-                if request_hash.key?(key.to_s)
-                  extracted_data[key] = extract(nested_filters, request_hash.fetch(key.to_s))
+                stringified_key = key.to_s
+                if request_hash.key?(stringified_key)
+                  value = request_hash.fetch(stringified_key)
+                  extracted_data[key] = value.nil? ? nil : extract(nested_filters, value)
                 end
               end
             end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.0.1"
+  spec.version       = "4.0.2"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/extractors/body_param_extractor_spec.rb
+++ b/spec/salestation/web/extractors/body_param_extractor_spec.rb
@@ -77,5 +77,29 @@ describe Salestation::Web::Extractors::BodyParamExtractor do
         expect(result.value).to eq(expected_result)
       end
     end
+
+    context 'when nested value is nil' do
+      let(:params) { {'x' => 'y', 'foo' => nil} }
+      let(:expected_result) { {x: 'y', foo: nil} }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+
+    context 'when nested value is empty' do
+      let(:params) { {'x' => 'y', 'foo' => {}} }
+      let(:expected_result) { {x: 'y', foo: {}} }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
   end
 end


### PR DESCRIPTION
If nested parameters are specified, i.e. `BodyParamExtractor[:x, {foo: [:bar]}]`,
but the input given is `{'x' => 'y', 'foo' => nil}`, then extracting the
parameters fails with the following error:

```
NoMethodError:
  undefined method `key?' for nil:NilClass
```

Which happens because `request_hash` is `nil` on the following line:

```
lib/salestation/web/extractors.rb:125
  extracted_data[filter] = request_hash[stringified_key] if request_hash.key?(stringified_key)
```

Change the extractor so that it wouldn't try to parse the nested
parameters if the root parameter is `nil`.