### PR TITLE
Support older `dry-types` versions

### DIFF
--- a/lib/salestation/app.rb
+++ b/lib/salestation/app.rb
@@ -7,7 +7,12 @@ require 'dry-types'
 module Salestation
   class App
     module Types
-      include Dry::Types()
+      dry_types_version = Gem.loaded_specs['dry-types'].version
+      if dry_types_version < Gem::Version.new('0.15.0')
+        include Dry::Types.module
+      else
+        include Dry::Types()
+      end
     end
 
     def initialize(env:, hooks: {})

--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -8,7 +8,12 @@ require 'json'
 module Salestation
   class Web < Module
     module Types
-      include Dry::Types()
+      dry_types_version = Gem.loaded_specs['dry-types'].version
+      if dry_types_version < Gem::Version.new('0.15.0')
+        include Dry::Types.module
+      else
+        include Dry::Types()
+      end
     end
 
     def initialize(errors: {})

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.0.2"
+  spec.version       = "4.0.3"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Include `dry-types` in a version dependent way, to also support older
versions of the library. Some of our services still use older versions
of the `dry-*` libraries because updating them may require a lot of
work.