### PR TITLE
Make debug_message and message optional

### DIFF
--- a/lib/salestation/app/errors.rb
+++ b/lib/salestation/app/errors.rb
@@ -12,44 +12,44 @@ module Salestation
       end
 
       class InvalidInput < Error
-        attribute :errors, Types::Strict::Hash
-        attribute :hints, Types::Coercible::Hash.default({}.freeze)
+        attribute? :errors, Types::Strict::Hash
+        attribute? :hints, Types::Coercible::Hash.default({}.freeze)
         attribute? :debug_message, Types::Strict::String
         attribute? :form_errors, Types::Strict::Bool.default(false)
       end
 
       class DependencyCurrentlyUnavailable < Error
-        attribute :message, Types::Strict::String
+        attribute? :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
       class RequestedResourceNotFound < Error
-        attribute :message, Types::Strict::String
+        attribute? :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
       class Forbidden < Error
-        attribute :message, Types::Strict::String
+        attribute? :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
 
       class Conflict < Error
-        attribute :message, Types::Strict::String
-        attribute :debug_message, Types::Strict::String
+        attribute? :message, Types::Strict::String
+        attribute? :debug_message, Types::Strict::String
       end
 
       class NotAcceptable < Error
-        attribute :message, Types::Strict::String
-        attribute :debug_message, Types::Strict::String
+        attribute? :message, Types::Strict::String
+        attribute? :debug_message, Types::Strict::String
       end
 
       class UnsupportedMediaType < Error
-        attribute :message, Types::Strict::String
-        attribute :debug_message, Types::Strict::String
+        attribute? :message, Types::Strict::String
+        attribute? :debug_message, Types::Strict::String
       end
 
       class RequestEntityTooLarge < Error
-        attribute :message, Types::Strict::String
+        attribute? :message, Types::Strict::String
         attribute? :debug_message, Types::Strict::String
       end
     end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.0.3"
+  spec.version       = "4.1.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/responses/error_spec.rb
+++ b/spec/salestation/web/responses/error_spec.rb
@@ -57,6 +57,16 @@ describe Salestation::Web::Responses::Error do
     end
   end
 
+  context 'when message is not provided' do
+    let(:base_error) { {message: 'base_error_message'} }
+    let(:message) { nil }
+
+    it 'uses message from base_error' do
+      error = create_error
+      expect(create_error.body).to eql(message: 'base_error_message', debug_message: debug_message)
+    end
+  end
+
   context 'when debug message is missing' do
     let(:attributes) { all_attributes.except(:debug_message) }
 

--- a/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
+++ b/spec/salestation/web/responses/unprocessable_entity_from_schema_errors_spec.rb
@@ -110,4 +110,16 @@ describe Salestation::Web::Responses::UnprocessableEntityFromSchemaErrors do
       expect(error.body.key?(:form_errors)).to eq(false)
     end
   end
+
+  context 'when no error and hints' do
+    let(:attributes) { {
+      errors: nil,
+      hints: nil
+    } }
+
+    it 'sets message and debug_message to their default value' do
+      expect(error.message).to eq(nil)
+      expect(error.debug_message).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
Currently when using `.from` with Glia errors we need to provide Glia
error and legacy message even for new endpoints where legacy message is
not needed. To avoid this make `message` optional. Also make
`debug_message` optional for more errors, as it's optional for some
errors already.

Also the same applies to `errors` and `hints` from dry-validation, which
we do not need anymore if Glia error is used.

CHAN-1403