### PR TITLE
Add RSpec matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ You can configure per-request tags by defining `salestation.statsd.tags` in sina
   end
 ```
 
+## RSpec helpers
+
+
+To use Salestation RSpec matchers you first need to include them:
+
+```
+require 'salestation/rspec'
+
+RSpec.configure do |config|
+  config.include Salestation::RSpec::Matchers
+end
+```
+
+After that it's possible to match against error results like this:
+
+```
+expect(result).to be_failure
+  .with_conflict
+  .containing(message: 'Oh noes')
+```
+
+See lib/salestation/rspec.rb for more examples.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/salestation/rspec.rb
+++ b/lib/salestation/rspec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+require 'salestation/app'
+
+require_relative './rspec/failure_matcher'
+require_relative './rspec/glia_input_validation_error_matcher'
+
+module Salestation
+  module RSpec
+    # Usage:
+    #
+    # In your RSpec configuration first include the matchers:
+    #
+    #   RSpec.configure do |config|
+    #     config.include Salestation::RSpec::Matchers
+    #   end
+    #
+    # Then you can use the matchers like this:
+    #
+    #   expect(result).to be_failure
+    #     .with_conflict
+    #     .containing(message: 'Oh noes')
+    #
+    # or when using Glia Errors:
+    #
+    #   expect(result).to be_failure
+    #     .with_requested_resource_not_found
+    #     .containing(Glia::Errors::ResourceNotFoundError.new(resource: :user))
+    #
+    # or when matching input errors from Glia Errors:
+    #
+    #   expect(result).to be_failure
+    #     .with_invalid_input
+    #     .containing(glia_input_validation_error.on(:name).with_type(Glia::Errors::INVALID_VALUE_ERROR))
+    #
+    # or you could even match multiple input errors at the same time:
+    #   expect(result).to be_failure
+    #     .with_invalid_input
+    #     .containing(
+    #       glia_input_validation_error
+    #         .on(:name).with_type(Glia::Errors::INVALID_VALUE_ERROR)
+    #         .on(:email)
+    #         .on(:phone_number).with_type(Glia::Errors::INVALID_FORMAT_ERROR)
+    #     )
+    #
+    # Everything after be_failure is optional. You could also use `.containing`
+    # multiple times like this:
+    #
+    #   expect(result).to be_failure
+    #     .containing(Glia::Errors::ResourceNotFoundError.new(resource: :user))
+    #     .containing(hash_including(message: 'Overriden message'))
+    #
+    module Matchers
+      def be_failure
+        FailureMatcher.new
+      end
+
+      def glia_input_validation_error
+        GliaInputValidationErrorMatcher.new
+      end
+    end
+  end
+end

--- a/lib/salestation/rspec/failure_matcher.rb
+++ b/lib/salestation/rspec/failure_matcher.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+module Salestation
+  module RSpec
+    class FailureMatcher
+      include ::RSpec::Matchers::Composable
+
+      attr_reader :expected, :actual, :failure_message
+
+      def initialize
+        @contents_matchers = []
+      end
+
+      def with(error_class)
+        @error_class = error_class
+        self
+      end
+
+      # From: active_support/inflector/methods.rb
+      def self.underscore(camel_cased_word)
+        return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+        word = camel_cased_word.to_s.gsub("::", "/")
+        word.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
+        word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
+        word.tr!("-", "_")
+        word.downcase!
+        word
+      end
+      private_class_method :underscore
+
+      # Defined methods using error class names:
+      #   with_conflict
+      #   with_invalid_input
+      #   ...
+      Salestation::App::Errors.constants.each do |class_name|
+        define_method(:"with_#{underscore(class_name.to_s)}") do
+          with(Salestation::App::Errors.const_get(class_name))
+          self
+        end
+      end
+
+      def containing(matcher)
+        @contents_matchers << matcher
+        self
+      end
+
+      def matches?(actual)
+        check_failure(actual) &&
+          check_error_type(actual) &&
+          check_contents(actual)
+      end
+
+      def diffable?
+        true
+      end
+
+      private
+
+      def check_failure(actual)
+        return true if actual.class == Deterministic::Result::Failure
+
+        @failure_message = "Expected Failure(...), but got #{actual.inspect}"
+        @expected = Deterministic::Result::Failure
+        @actual = actual.class
+        false
+      end
+
+      def check_error_type(actual)
+        return true unless @error_class
+        return true if actual.value.class == @error_class
+
+        @failure_message = "Expected failure to include #{@error_class}, but got #{actual.value.inspect}"
+        @expected = @error_class
+        @actual = actual.value.class
+        false
+      end
+
+      def check_contents(actual)
+        return true if @contents_matchers.empty?
+
+        has_error = @contents_matchers.detect do |contents_matcher|
+          if contents_matcher.is_a?(Hash) || rspec_matcher?(contents_matcher)
+            verify_contents_using_regular_matcher!(contents_matcher, actual)
+          else
+            verify_contents_using_base_error!(contents_matcher, actual)
+          end
+        end
+
+        !has_error
+      end
+
+      # Returns true when error was detected
+      def verify_contents_using_regular_matcher!(contents_matcher, actual)
+        return false if values_match?(contents_matcher, actual.value.to_h)
+
+        @failure_message = "Contents in #{actual.value.class} do not match"
+        @expected = contents_matcher
+        @actual = actual.value.to_h
+
+        true
+      end
+
+      # Returns true when error was detected
+      def verify_contents_using_base_error!(contents_matcher, actual)
+        # Compare hashes if possible, otherwise expect it to respond to `#matches?`.
+        contents_matcher = contents_matcher.to_h if contents_matcher.respond_to?(:to_h)
+
+        return false if values_match?(contents_matcher, actual.value[:base_error])
+
+        @failure_message = "Expected failure to be based on #{contents_matcher}, but got #{actual.value.inspect}"
+        @expected = contents_matcher
+        @actual = actual.value[:base_error].to_h
+
+        true
+      end
+
+      def rspec_matcher?(matcher)
+        # Didn't find a better way to detect matchers like HashIncludingMatcher
+        matcher.class.to_s.start_with?('RSpec')
+      end
+    end
+  end
+end

--- a/lib/salestation/rspec/glia_input_validation_error_matcher.rb
+++ b/lib/salestation/rspec/glia_input_validation_error_matcher.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+module Salestation
+  module RSpec
+    class GliaInputValidationErrorMatcher
+      include ::RSpec::Matchers::Composable
+
+      attr_reader :expected, :actual, :failure_message
+
+      def initialize
+        @fields = []
+        @field_error_types = {}
+      end
+
+      def on(field)
+        @fields << field
+        self
+      end
+
+      def with_type(*types)
+        @field_error_types[@fields.last] = types
+        self
+      end
+
+      def matches?(actual)
+        @fields.all? do |field|
+          check_field_exists(field, actual) &&
+            check_field_error_types(field, actual)
+        end
+      end
+
+      private
+
+      def check_field_exists(field, actual)
+        actual[:error_details].key?(field)
+      end
+
+      def check_field_error_types(field, actual)
+        return true unless @field_error_types[field]
+
+        actual_error_types = actual[:error_details].fetch(field).map { |f| f.fetch(:type) }
+
+        (@field_error_types[field] - actual_error_types).empty?
+      end
+    end
+  end
+end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10.4"
+  spec.add_development_dependency "glia-errors", "~> 0.8"
+  spec.add_development_dependency "dry-validation"
 
   spec.add_dependency 'deterministic'
   spec.add_dependency 'dry-struct'

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.1.0"
+  spec.version       = "4.2.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/rspec/failure_matcher_spec.rb
+++ b/spec/rspec/failure_matcher_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'glia/errors'
+require 'dry/validation'
+
+describe Salestation::RSpec::FailureMatcher do
+  include Deterministic::Prelude
+  Errors = Salestation::App::Errors
+
+  it 'works end to end' do
+    result = Deterministic::Result::Failure(
+      Salestation::App::Errors::InvalidInput.new(
+        errors: { name: ['is invalid'] },
+        debug_message: 'debug message'
+      )
+    )
+
+    expect(result).to be_failure
+      .with_invalid_input
+      .containing(hash_including(errors: { name: ['is invalid'] }))
+  end
+
+  it 'fails when result is not a failure' do
+    expect(
+      matcher.matches?(
+        Success(Errors::Conflict.new(message: 'message'))
+      )
+    ).to eq(false)
+  end
+
+  it 'succeeds when result is a failure' do
+    expect(
+      matcher.matches?(
+        Failure(Errors::Conflict.new(message: 'message'))
+      )
+    ).to eq(true)
+  end
+
+  it 'fails when error type is different' do
+    expect(
+      matcher.with_invalid_input.matches?(
+        Failure(Errors::Conflict.new(message: 'message'))
+      )
+    ).to eq(false)
+  end
+
+  it 'succeeds when error type is the same' do
+    expect(
+      matcher.with_conflict.matches?(
+        Failure(Errors::Conflict.new(message: 'message'))
+      )
+    ).to eq(true)
+  end
+
+  it 'fails when error contents are different' do
+    expect(
+      matcher.with_conflict.containing(hash_including(message: 'foo')).matches?(
+        Failure(Errors::Conflict.new(message: 'bar'))
+      )
+    ).to eq(false)
+  end
+
+  it 'succeeds when error contents match' do
+    expect(
+      matcher.with_conflict.containing(hash_including(message: 'foo')).matches?(
+        Failure(Errors::Conflict.new(message: 'foo'))
+      )
+    ).to eq(true)
+  end
+
+  it 'succeeds when error contents are exactly the same' do
+    expect(
+      matcher.with_conflict.containing(message: 'foo').matches?(
+        Failure(Errors::Conflict.new(message: 'foo'))
+      )
+    ).to eq(true)
+  end
+
+  context 'when using with Glia Errors' do
+    it 'succeeds when base error is the same' do
+      failure = Failure(
+        Errors::RequestedResourceNotFound.from(
+          Glia::Errors::ResourceNotFoundError.new(resource: :user)
+        )
+      )
+
+      expect(
+        matcher
+          .with_requested_resource_not_found
+          .containing(Glia::Errors::ResourceNotFoundError.new(resource: :user))
+          .matches?(failure)
+      ).to eq(true)
+    end
+
+    it 'fails when base error has different contents' do
+      failure = Failure(
+        Errors::RequestedResourceNotFound.from(
+          Glia::Errors::ResourceNotFoundError.new(resource: :article)
+        )
+      )
+
+      expect(
+        matcher
+          .with_requested_resource_not_found
+          .containing(Glia::Errors::ResourceNotFoundError.new(resource: :user))
+          .matches?(failure)
+      ).to eq(false)
+    end
+
+  end
+
+  context 'when using with Glia Errors & dry-validation' do
+    let(:schema) do
+      Dry::Validation.Contract do
+        params do
+          required(:name).filled { type?(String) & min_size?(5) }
+          required(:email).filled { type?(String) }
+        end
+      end
+    end
+
+    it 'succeeds when field name matches' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(glia_input_validation_error.on(:name))
+          .matches?(failure)
+      ).to eq(true)
+    end
+
+    it 'succeeds when one field type matches' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(glia_input_validation_error.on(:name).with_type(Glia::Errors::INVALID_VALUE_ERROR))
+          .matches?(failure)
+      ).to eq(true)
+    end
+
+    it 'succeeds when multiple field types match' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(
+            glia_input_validation_error
+              .on(:name).with_type(Glia::Errors::INVALID_VALUE_ERROR)
+              .on(:email).with_type(Glia::Errors::INVALID_VALUE_ERROR)
+          )
+          .matches?(failure)
+      ).to eq(true)
+    end
+
+    it 'fails when one field type of multiple field types does not match' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(
+            glia_input_validation_error
+              .on(:name).with_type(Glia::Errors::LIMIT_EXCEEDED_ERROR)
+              .on(:email).with_type(Glia::Errors::INVALID_VALUE_ERROR)
+          )
+          .matches?(failure)
+      ).to eq(false)
+    end
+
+    it 'allows only some of the fields to have with_type matcher' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(
+            glia_input_validation_error
+              .on(:name)
+              .on(:email).with_type(Glia::Errors::INVALID_VALUE_ERROR)
+          )
+          .matches?(failure)
+      ).to eq(true)
+    end
+
+    it 'fails when glia error field type does not match' do
+      validation_result = schema.call(name: nil, email: nil)
+
+      failure = Failure(
+        Errors::InvalidInput.from(
+          Glia::Errors.from_dry_validation_result(validation_result),
+          errors: validation_result.errors.to_h,
+          hints: {}
+        )
+      )
+
+      expect(
+        matcher
+          .with_invalid_input
+          .containing(glia_input_validation_error.on(:name).with_type(Glia::Errors::LIMIT_EXCEEDED_ERROR))
+          .matches?(failure)
+      ).to eq(false)
+    end
+  end
+
+  def matcher
+    described_class.new
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "salestation"
+
+require 'salestation'
+require 'salestation/rspec'
+
 require 'pry'
 require_relative './salestation/support/hook_mock'
 
@@ -12,4 +15,5 @@ end
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.include Salestation::RSpec::Matchers
 end


### PR DESCRIPTION
These make it easier to match and validate errors. Previously we defiend 
similar matchers separately in projects but there were some problems:

* They were slightly different across projects
* Matching errors almost never gave any useful information
* Validating input errors was especially annoying

I also included GliaInputValidationErrorMatcher in this project. You could
argue that this should be part of `glia-errors` project, but as this is
just starting out and we need to test the matchers composition, it is
easier if they're in the same place. If the matcher gets mature then I
think we could also more it to glia-errors.