### PR TITLE
Consider all mime types in the Accept header

### DIFF
--- a/lib/salestation/web/input_validators/accept_header.rb
+++ b/lib/salestation/web/input_validators/accept_header.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'http/accept'
+
 module Salestation
   class Web < Module
     module InputValidators
@@ -15,9 +17,11 @@ module Salestation
         end
 
         def call(header_value)
-          header_valid = @allowed_headers.empty? || @allowed_headers.include?(header_value)
+          return Success(nil) if @allowed_headers.empty?
 
-          if header_valid
+          mime_types = HTTP::Accept::MediaTypes.parse(header_value).map(&:mime_type)
+
+          if (@allowed_headers & mime_types).any?
             Success(nil)
           else
             Failure(App::Errors::NotAcceptable.new(

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deterministic'
   spec.add_dependency 'dry-struct'
   spec.add_dependency 'dry-types'
+  spec.add_dependency 'http-accept', '~> 2.1'
 end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.2.0"
+  spec.version       = "4.3.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/input_validators/accept_header_spec.rb
+++ b/spec/salestation/web/input_validators/accept_header_spec.rb
@@ -26,4 +26,20 @@ describe Salestation::Web::InputValidators::AcceptHeader do
       expect(validate_header).to be_success
     end
   end
+
+  context 'when one of the accept mime types is allowed' do
+    let(:header_value) { 'application/vnd.salemove.v1+json, application/json' }
+
+    it 'returns success' do
+      expect(validate_header).to be_success
+    end
+  end
+
+  context 'when none of the accept mime types are allowed' do
+    let(:header_value) { 'application/csv, text/plain' }
+
+    it 'returns failure' do
+      expect(validate_header).to be_failure
+    end
+  end
 end


### PR DESCRIPTION
[Accept header][1] allows providing multiple mime types: e.g.
`Accept: application/json, application/xml`. Previously we considered 
everything after `Accept` as one mime type. So if an API client provided 
multiple mime types they always received an error even though it included a
valid mime type.

I decided to use [http-accept][2] library for this. It handles the complex
Accept header parsing and doesn't have any additional dependencies.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
[2]: https://github.com/socketry/http-accept