### PR TITLE
Dot not require `errors` and `hints` to be assigned

### DIFF
--- a/lib/salestation/web/responses.rb
+++ b/lib/salestation/web/responses.rb
@@ -66,7 +66,7 @@ module Salestation
       end
 
       class UnprocessableEntityFromSchemaErrors
-        def self.create(errors:, hints:, base_error: nil, form_errors: false)
+        def self.create(errors: nil, hints: nil, base_error: nil, form_errors: false)
           message = errors ? parse_errors(errors) : nil
           debug_message = hints ? parse_hints(hints) : nil
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.3.0"
+  spec.version       = "4.3.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Set `errors` and `hints` default values when mapping to
`UnprocessableEntity` errors. Note that the current validation schema
allows `errors` to be missing but does not allow it to be set to `nil`
explicitly.