### PR TITLE
Add HTTP Origin to request logger

### DIFF
--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -11,6 +11,7 @@ module Salestation
       CONTENT_TYPE = 'CONTENT_TYPE'
       HTTP_USER_AGENT = 'HTTP_USER_AGENT'
       HTTP_ACCEPT = 'HTTP_ACCEPT'
+      HTTP_ORIGIN = 'HTTP_ORIGIN'
       SERVER_NAME = 'SERVER_NAME'
 
       def initialize(app, logger, log_response_body: false, level: :info)
@@ -53,6 +54,7 @@ module Salestation
           content_type: env[CONTENT_TYPE],
           http_agent:   env[HTTP_USER_AGENT],
           http_accept:  env[HTTP_ACCEPT],
+          http_origin:  env[HTTP_ORIGIN],
           server_name:  env[SERVER_NAME],
           status:       status,
           duration:     duration(from: began_at),

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.3.1"
+  spec.version       = "4.4.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
[Origin][1] request header indicates where a request originates from. It 
doesn't include any path information.

This helps to understand how endpoints are being used.

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin