### PR TITLE
Handle missing Accept header without crashing

### DIFF
--- a/lib/salestation/web/input_validators/accept_header.rb
+++ b/lib/salestation/web/input_validators/accept_header.rb
@@ -19,7 +19,7 @@ module Salestation
         def call(header_value)
           return Success(nil) if @allowed_headers.empty?
 
-          mime_types = HTTP::Accept::MediaTypes.parse(header_value).map(&:mime_type)
+          mime_types = HTTP::Accept::MediaTypes.parse(header_value.to_s).map(&:mime_type)
 
           if (@allowed_headers & mime_types).any?
             Success(nil)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.4.0"
+  spec.version       = "4.4.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/input_validators/accept_header_spec.rb
+++ b/spec/salestation/web/input_validators/accept_header_spec.rb
@@ -7,6 +7,18 @@ describe Salestation::Web::InputValidators::AcceptHeader do
     described_class['application/json'].call(header_value)
   end
 
+  context 'when header is not provided' do
+    let(:header_value) { nil }
+
+    it 'returns failure' do
+      expect(validate_header).to be_failure
+      expect(validate_header.value).to eq(Salestation::App::Errors::NotAcceptable.new(
+        message: "Unsupported Accept Header '#{header_value}'",
+        debug_message: "Available Accept Headers are application/json"
+      ))
+    end
+  end
+
   context 'when header is not allowed' do
     let(:header_value) { 'application/xml' }
 


### PR DESCRIPTION
Since Salestation 4.3.0 missing accept header caused an TypeError in
`http-accept` library, (and caused the request to fail with 500)

This fix ensures that a string is passed to this library
and a request with a missing `Accept` header gets a proper response.