### PR TITLE
Migrate to Github Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,31 @@
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Salestation
-
-[![Build Status](https://travis-ci.org/salemove/salestation.svg?branch=master)](https://travis-ci.org/salemove/salestation)
+![Build Status](https://github.com/salemove/salestation/actions/workflows/ruby.yml/badge.svg)
 
 ## Installation
 
@@ -221,4 +220,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/[USERN
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10.4"
-  spec.add_development_dependency "glia-errors", "~> 0.8"
+  spec.add_development_dependency "glia-errors", "~> 0.11.4"
   spec.add_development_dependency "dry-validation"
 
   spec.add_dependency 'deterministic'

--- a/spec/rspec/failure_matcher_spec.rb
+++ b/spec/rspec/failure_matcher_spec.rb
@@ -197,7 +197,7 @@ describe Salestation::RSpec::FailureMatcher do
           .with_invalid_input
           .containing(
             glia_input_validation_error
-              .on(:name).with_type(Glia::Errors::LIMIT_EXCEEDED_ERROR)
+              .on(:name).with_type(Glia::Errors::RESOURCE_LIMIT_EXCEEDED_ERROR)
               .on(:email).with_type(Glia::Errors::INVALID_VALUE_ERROR)
           )
           .matches?(failure)
@@ -241,7 +241,7 @@ describe Salestation::RSpec::FailureMatcher do
       expect(
         matcher
           .with_invalid_input
-          .containing(glia_input_validation_error.on(:name).with_type(Glia::Errors::LIMIT_EXCEEDED_ERROR))
+          .containing(glia_input_validation_error.on(:name).with_type(Glia::Errors::RESOURCE_LIMIT_EXCEEDED_ERROR))
           .matches?(failure)
       ).to eq(false)
     end


### PR DESCRIPTION
https://travis-ci.org/ does not run build anymore since June 15th 2021
and requires migration to travis-ci.com.

Instead we can use Github actions which is free for public repos.