### PR TITLE
Automatically publish package on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Gem
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+
+      - name: Release Gem
+        uses: discourse/publish-rubygems-action@b55d7b91b55e61752dc6cbc2972f8e16fe6c1a02
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ See lib/salestation/rspec.rb for more examples.
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. A new version is created when a change is merged into the master branch that changes the version number in `salestation.gemspec`. A Github Action will create a tag for the version and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 


### PR DESCRIPTION
Previously the package needed to be manually published by somebody with
permissions. This is a hasstle if the changes were authored by somebody without
permissions. A Github Action will automatically publish a new version and add a
tag when changes are merged to master that increase the version number in
`salestation.gemspec`. If the version in unchanged when changes are merged then
the action fails but does so silently.

CHAN-1774