### PR TITLE
Return original input on schema call

### DIFF
--- a/lib/salestation/app/input_verification.rb
+++ b/lib/salestation/app/input_verification.rb
@@ -5,7 +5,8 @@ module Salestation
     module InputVerification
       def verify_input(schema)
         -> (request) do
-          result = schema.call(request.input)
+          input = request.input
+          result = schema.call(input)
 
           dry_validation_version = Gem.loaded_specs['dry-validation'].version
           if dry_validation_version < Gem::Version.new('1.0')
@@ -19,7 +20,7 @@ module Salestation
             end
           elsif dry_validation_version <= Gem::Version.new('1.8')
             if result.success?
-              request.replace_input(result.to_h)
+              request.replace_input(input)
             else
               Deterministic::Result::Failure(
                 Errors::InvalidInput.new(errors: result.errors.to_h, hints: result.hints.to_h)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.6.0"
+  spec.version       = "4.6.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
When a schema is validated the keys are removed that are not specifiedin
the schema. Such as if the schema does not include the `requester` key,
after validation that key will no longer exist.

MSG-75

An example of where this is used is https://github.com/salemove/engagement-registry/blob/master/lib/app/engagement/update_engagement_request.rb#L10

These are the changes on the master PR which have the same behaviour. https://github.com/salemove/engagement-registry/pull/1536/files#diff-7e2ab0f252421959a12b6f4e644a39ebb726b89d09e767763513d1ee87283a3a