### PR TITLE
Add body param extraction for array of hashes

### DIFF
--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "4.6.1"
+  spec.version       = "5.0.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/spec/salestation/web/extractors/body_param_extractor_spec.rb
+++ b/spec/salestation/web/extractors/body_param_extractor_spec.rb
@@ -54,10 +54,10 @@ describe Salestation::Web::Extractors::BodyParamExtractor do
   end
 
   context 'with nested keys' do
-    subject(:extract_body_params) { described_class[:x, {foo: [:bar]}].call(request) }
+    subject(:extract_body_params) { described_class[:x, {foo: [:bar, {a: [:b]}]}].call(request) }
 
-    let(:params) { {'x' => 'y', 'foo' => {'bar' => 'baz'}} }
-    let(:expected_result) { {x: 'y', foo: {bar: 'baz'}} }
+    let(:params) { {'x' => 'y', 'foo' => {'bar' => 'baz', 'a' => {'b' => 'c'}}} }
+    let(:expected_result) { {x: 'y', foo: {bar: 'baz', a: {b: 'c'}}} }
 
     it 'extracts body params from request' do
       result = extract_body_params
@@ -93,6 +93,80 @@ describe Salestation::Web::Extractors::BodyParamExtractor do
     context 'when nested value is empty' do
       let(:params) { {'x' => 'y', 'foo' => {}} }
       let(:expected_result) { {x: 'y', foo: {}} }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+
+    context 'when nested value is not a hash' do
+      let(:params) { {'x' => 'y', 'foo' => 'bar' } }
+      let(:expected_result) { {x: 'y', foo: 'bar' } }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+  end
+
+  context 'with array of hashes' do
+    subject(:extract_body_params) { described_class[:x, :webhooks].call(request) }
+
+    let(:params) { {'x' => 'y', 'webhooks' => [ {'foo' => 'bar'} ] } }
+    let(:expected_result) { {x: 'y', webhooks: [ {foo: 'bar'} ] } }
+
+    it 'extracts body params from request' do
+      result = extract_body_params
+
+      expect(result).to be_a(Deterministic::Result::Success)
+      expect(result.value).to eq(expected_result)
+    end
+
+    context 'when array is empty' do
+      let(:params) { {'x' => 'y', 'webhooks' => [] } }
+      let(:expected_result) { {x: 'y', webhooks: [] } }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+
+    context 'when hash is nil' do
+      let(:params) { {'x' => 'y', 'webhooks' => [ nil ] } }
+      let(:expected_result) { {x: 'y', webhooks: [ nil ] } }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+
+    context 'when hash is empty' do
+      let(:params) { {'x' => 'y', 'webhooks' => [ {} ] } }
+      let(:expected_result) { {x: 'y', webhooks: [ {} ] } }
+
+      it 'extracts body params from request' do
+        result = extract_body_params
+
+        expect(result).to be_a(Deterministic::Result::Success)
+        expect(result.value).to eq(expected_result)
+      end
+    end
+
+    context 'when array is strings' do
+      let(:params) { {'x' => 'y', 'webhooks' => [ "foobar" ] } }
+      let(:expected_result) { {x: 'y', webhooks: [ "foobar" ] } }
 
       it 'extracts body params from request' do
         result = extract_body_params


### PR DESCRIPTION
This change is specifically to address extracting the webhook param in
engagement-api. Webhooks are specified as an array of hashes. The
previous functionality would lead to the array of hashes to have strings
for keys, while the `webhooks` key is a symbol.

The new version of dry-schema wants all keys to be a symbol. So when a
key was a string, the key was not found and the validation failed.

This implementation checks if the key's result is an array, to symbolize
all keys in the nested array of hashes structure. There should be no
need to specify all the keys in the webhooks as these are validated with
dry-schema.

MSG-75
MSG-71