### PR TITLE
Support future dry-validation versions

### DIFF
--- a/lib/salestation/app/input_verification.rb
+++ b/lib/salestation/app/input_verification.rb
@@ -18,7 +18,7 @@ module Salestation
                 Errors::InvalidInput.new(errors: result.errors, hints: result.hints)
               )
             end
-          elsif dry_validation_version <= Gem::Version.new('1.8')
+          elsif dry_validation_version < Gem::Version.new('2.0')
             if result.success?
               request.replace_input(input)
             else

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.0.0"
+  spec.version       = "5.0.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
When upgrading dry-validation to above 1.8, such as to 1.8.1,
it raised unsupported version.