### PR TITLE
Add message matcher

### DIFF
--- a/lib/salestation/rspec/glia_input_validation_error_matcher.rb
+++ b/lib/salestation/rspec/glia_input_validation_error_matcher.rb
@@ -12,6 +12,7 @@ module Salestation
       def initialize
         @fields = []
         @field_error_types = {}
+        @field_error_messages = {}
       end
 
       def on(field)
@@ -24,10 +25,16 @@ module Salestation
         self
       end
 
+      def with_message(*messages)
+        @field_error_messages[@fields.last] = messages
+        self
+      end
+
       def matches?(actual)
         @fields.all? do |field|
           check_field_exists(field, actual) &&
-            check_field_error_types(field, actual)
+            check_field_error_types(field, actual) &&
+            check_field_error_messages(field, actual)
         end
       end
 
@@ -43,6 +50,14 @@ module Salestation
         actual_error_types = actual[:error_details].fetch(field).map { |f| f.fetch(:type) }
 
         (@field_error_types[field] - actual_error_types).empty?
+      end
+
+      def check_field_error_messages(field, actual)
+        return true unless @field_error_messages[field]
+
+        actual_error_messages = actual[:error_details].fetch(field).map { |f| f.fetch(:message) }
+
+        (@field_error_messages[field] - actual_error_messages).empty?
       end
     end
   end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.0.1"
+  spec.version       = "5.0.2"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
A new method `with_message` in the Failure matcher, matches the error
string. This can be used to provide more context on what error string is
being returned in glia errors.

MSG-85