### PR TITLE
Symbolize body parameters keys recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Multiple extractors can be merged together. If two or more extractors use the sa
 
 `coercions` can optionally be provided to `BodyParamExtractor` and `QueryParamExtractor`. These can be used to transform the values of the extracted parameters.
 
+#### ParamExtractor
+
+ParamExtractor, which is also used by `BodyParamExtractor` and `QueryParamExtractor`, 
+extracts only the content of such root level keys that are specified when creating the
+extractor instance. All other root level keys are discarded. Everything inside the 
+whitelisted root level keys is automatically whitelisted.
+
+
 Define a route
 
 ```ruby

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.1.0"
+  spec.version       = "5.2.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-struct'
   spec.add_dependency 'dry-types'
   spec.add_dependency 'http-accept', '~> 2.1'
+  spec.add_dependency 'symbolizer'
 end


### PR DESCRIPTION
ParamExtractor class was capable of symbolizing keys only to a certain
level in an object hierarchy. After changes, the logic is capable of
doing it recursively to however many levels of hierarchy.

The change was needed because new Dry validation libraries require all
keys to be symbolic. If key is a string, the validation library does
not find it and validation fails. So, all keys need to be symbolized.

In particular, there is a complex nested object that needs validation
in the overseer project. The object has an array of hashes, where inside
the hash, there is another array of hashes. The deeper array was not
covered by earlier extraction logic.

As before, the “filters” used in the extractor (the list of highest
level keys of the object that is extracted) can be simply symbols, or
also a hash of symbols. E.g. the filters list is allowed to look both 
like [:key1, :key2] and [:key1, {key2: %i[sub_key1 sub_key2]]

In reality, it is not anymore needed to use hashes of symbols. The
“filters” can also in the second case look like [:key1, :key2]. All 
sublevels of the keys will be symbolized anyhow, with the new 
recursive approach.