### PR TITLE
Add module `IPAddress` to extract `ip_address` from request

### DIFF
--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -44,6 +44,7 @@ module Salestation
 end
 
 require_relative './web/extractors'
+require_relative './web/ip_address'
 require_relative './web/responses'
 require_relative './web/error_mapper'
 require_relative './result_helper'

--- a/lib/salestation/web/ip_address.rb
+++ b/lib/salestation/web/ip_address.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Salestation
+  class Web < Module
+    module IPAddress
+      def self.extract(request)
+        if request['HTTP_X_FORWARDED_FOR'].nil?
+          request['REMOTE_ADDR']
+        else
+          request['HTTP_X_FORWARDED_FOR'].split(',').first
+        end
+      end
+    end
+  end
+end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.2.0"
+  spec.version       = "5.3.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.10.4"
   spec.add_development_dependency "glia-errors", "~> 0.11.4"
-  spec.add_development_dependency "dry-validation", "~> 1.7.0"
+  spec.add_development_dependency "dry-validation", "~> 1.7"
 
   spec.add_dependency 'deterministic'
   spec.add_dependency 'dry-struct'

--- a/spec/salestation/web/ip_address_spec.rb
+++ b/spec/salestation/web/ip_address_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Salestation::Web::IPAddress do
+  let(:ip_address) do
+    described_class
+  end
+
+  describe '.extract' do
+    it 'returns IP address in X-Forwarded-For header' do
+      request = { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, 4.3.2.1', 'REMOTE_ADDR' => '5.6.7.8' }
+      expect(ip_address.extract(request)).to eq('1.2.3.4')
+      request = { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4, 4.3.2.1' }
+      expect(ip_address.extract(request)).to eq('1.2.3.4')
+      request = { 'HTTP_X_FORWARDED_FOR' => '1.2.3.4' }
+      expect(ip_address.extract(request)).to eq('1.2.3.4')
+    end
+
+    it 'returns IP from REMOTE_ADDR if X-Forwarded-For not present' do
+      request = { 'REMOTE_ADDR' => '5.6.7.8' }
+      expect(ip_address.extract(request)).to eq('5.6.7.8')
+    end
+  end
+end


### PR DESCRIPTION
Module IPAddress with method extract added as part of Audit Trail project: https://glia.atlassian.net/wiki/spaces/ENG/pages/3127214099/Audit+Trails+Audit-logger The project requires to have available de ip from where the request to log was made. Since obtaining the ip from the headers include a small logic, to avoid having to add this logic to every service it was decided to be added as a method in the library.

SUDO-601

_Initially it was thought to be part of library `ruby_authentication`,[ but as indicated in the previously proposed PR](https://github.com/salemove/ruby_authentication/pull/26), the functionality was decided to be moved to `salestation` library._

-------------
For the specific purpose of project Audit Trail this has been tested in `overseer` project, implemented as:
1. `include Salestation::Web::IPAddress` in `web_app.rb`
2. obtain the ip_address during the flow of auth_extracgtor.rb to add ip_address to the requester object
```
def self.[](target_key, jwt_authenticator:, application_token:)
        Salestation::Web::Extractors::InputExtractor.new do |web_request|
          auth_type, token = web_request.env['HTTP_AUTHORIZATION'].try(:split)
          ip_address = Salestation::Web::IPAddress(web_request.env).to_s
```