### PR TITLE
Handle keywords argument warning

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/salestation/web/error_mapper.rb
+++ b/lib/salestation/web/error_mapper.rb
@@ -7,7 +7,7 @@ module Salestation
 
       ERROR_TO_RESPONSE_DEFAULTS = {
         App::Errors::InvalidInput => -> (error) {
-          Responses::UnprocessableEntityFromSchemaErrors.create(error)
+          Responses::UnprocessableEntityFromSchemaErrors.create(**error)
         },
         App::Errors::DependencyCurrentlyUnavailable => -> (error) {
           Responses::ServiceUnavailable.new(

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.3.0"
+  spec.version       = "5.3.1"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

> In Ruby 3.0, positional arguments and keyword arguments will be separated.
> Ruby 2.7 will warn for behaviors that will change in Ruby 3.0.

I stumbled on this when running an app which uses Salestation.
I skimmed through other parts of the code to see if there are any
other places where keyword parameters don't match arguments
but I could not find any.