### PR TITLE
Support requiring an exact match for validation errors

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+--plugin yard-doctest

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 require 'yard/doctest/rake'
 
 RSpec::Core::RakeTask.new(:spec)

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'yard/doctest/rake'
 
 RSpec::Core::RakeTask.new(:spec)
+YARD::Doctest::RakeTask.new
 
-task :default => :spec
+task :default do
+  Rake::Task['spec'].invoke
+  Rake::Task['yard:doctest'].invoke
+end

--- a/lib/salestation/rspec/glia_input_validation_error_matcher.rb
+++ b/lib/salestation/rspec/glia_input_validation_error_matcher.rb
@@ -37,7 +37,7 @@ module Salestation
       end
 
       def matches?(actual)
-        check_exact_match(actual, path_list_to_trie(@fields)) &&
+        check_exact_match(actual, self.class.path_list_to_trie(@fields)) &&
           @fields.all? do |field|
             check_field_exists(actual, *field) &&
               check_field_error_types(field, actual) &&
@@ -104,18 +104,31 @@ module Salestation
         fields.join('->').to_sym
       end
 
-      def path_list_to_trie(paths)
-        paths.reduce({}) do |acc, path|
-          deep_merge(acc, path_to_trie(*path))
+      class << self
+        # @example
+        #  path_list_to_trie([[:a, :b, :c], [:a, :b, :d], [:a, :e]])
+        #  #=> {a: {b: {c: {}, d: {}}, e: {}}}
+        def path_list_to_trie(paths)
+          paths.reduce({}) do |acc, path|
+            deep_merge(acc, path_to_trie(*path))
+          end
         end
-      end
 
-      def path_to_trie(element, *rest)
-        {element.to_sym => rest.empty? ? {} : path_to_trie(*rest)}
-      end
+        private
 
-      def deep_merge(a, b)
-        a.merge(b) { |_key, nested_a, nested_b| deep_merge(nested_a, nested_b) }
+        # @example
+        #  path_to_trie(*[:a, :b, :c])
+        #  #=> {a: {b: {c: {}}}}
+        def path_to_trie(element, *rest)
+          {element.to_sym => rest.empty? ? {} : path_to_trie(*rest)}
+        end
+
+        # @example
+        #  deep_merge({a: {b: {c: {}}}}, {a: {b: {d: {}}, e: {}}})
+        #  #=> {a: {b: {c: {}, d: {}}, e: {}}}
+        def deep_merge(a, b)
+          a.merge(b) { |_key, nested_a, nested_b| deep_merge(nested_a, nested_b) }
+        end
       end
     end
   end

--- a/lib/salestation/web/extractors.rb
+++ b/lib/salestation/web/extractors.rb
@@ -61,14 +61,15 @@ module Salestation
       # Handles coercing input values
       #
       # @example
-      #  extractor = BodyParamExtractor[:x, :y]
+      #  extractor = Salestation::Web::Extractors::BodyParamExtractor[:x, :y]
       #    .coerce(x: ->(value) { "x_#{value}"})
       #  input = {
       #   'x' => 'a',
       #   'y' => 'b',
       #  }
       #  # rack_request is Rack::Request with 'rack.request.form_hash' set to input
-      #  extractor.call(rack_request).value #=> {x: 'x_a', y: 'b'}
+      #  extractor.call(rack_request(input)).value
+      #  #=> {x: 'x_a', y: 'b'}
       class InputCoercer
         def initialize(extractor, rules)
           @extractor = extractor
@@ -106,28 +107,25 @@ module Salestation
       # values can be compared in rename.
       #
       # @example
-      #  original_input = {
-      #    x: 'a',
-      #    y: 'b'
+      #  input = {
+      #    'x' => 'a',
+      #    'y' => 'b'
       #  }
       #
-      #  extractor = BodyParamExtractor[:x, :y]
+      #  extractor = Salestation::Web::Extractors::BodyParamExtractor[:x, :y]
       #    .rename(x: :z)
-      #  input = {
-      #    z: 'a',
-      #    y: 'b'
-      #  }
+      #  extractor.call(rack_request(input)).value
+      #  #=> {z: 'a', y: 'b'}
       #
-      #  extractor = BodyParamExtractor[:x, :y]
+      #  extractor = Salestation::Web::Extractors::BodyParamExtractor[:x, :y]
       #    .rename(x: :y)
-      #  input = {
-      #    y: 'b'
-      #  }
-      #  extractor = BodyParamExtractor[:x, :y]
+      #  extractor.call(rack_request(input)).value
+      #  #=> {y: 'b'}
+      #
+      #  extractor = Salestation::Web::Extractors::BodyParamExtractor[:x, :y]
       #    .rename(x: {new_key: :y, override: true})
-      #  input = {
-      #    y: 'a'
-      #  }
+      #  extractor.call(rack_request(input)).value
+      #  #=> {y: 'a'}
       class InputRenamer
         def initialize(extractor, rules)
           @extractor = extractor
@@ -217,7 +215,7 @@ module Salestation
       # Extracts and symbolizes params from request body
       #
       # @example
-      #  extractor = BodyParamExtractor[:x, :y, {foo: [:bar, :baz]}, :aaa]
+      #  extractor = Salestation::Web::Extractors::BodyParamExtractor[:x, :y, {foo: [:bar, :baz]}, :aaa]
       #  input = {
       #   'x' => '1',
       #   'y' => '2',
@@ -232,7 +230,8 @@ module Salestation
       #    ]
       #  }
       #  # rack_request is Rack::Request with 'rack.request.form_hash' set to input
-      #  extractor.call(rack_request).value #=> {x: 1, y: 2, foo: {bar: 'qq'}, aaa: [{bb: 'cc'}]}
+      #  extractor.call(rack_request(input)).value
+      #  #=> {x: '1', y: '2', foo: {bar: 'qq'}, aaa: [{bb: 'cc'}]}
       #
       class BodyParamExtractor
         def self.[](*filters)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.3.1"
+  spec.version       = "5.3.2"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.14.2"
   spec.add_development_dependency "glia-errors", "~> 0.11.4"
   spec.add_development_dependency "dry-validation", "~> 1.7"
+  spec.add_development_dependency "yard-doctest", "~> 0.1.17"
 
   spec.add_dependency 'deterministic'
   spec.add_dependency 'dry-struct'

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry", "~> 0.10.4"
+  spec.add_development_dependency "pry", "~> 0.14.2"
   spec.add_development_dependency "glia-errors", "~> 0.11.4"
   spec.add_development_dependency "dry-validation", "~> 1.7"
 

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
+require 'salestation'
+require 'salestation/rspec'
+
+def rack_request(input)
+  rack_request_class = Class.new do
+    def initialize(env_data)
+      @env = env_data
+    end
+    attr_reader :env
+  end
+  rack_request_class.new('rack.request.form_hash' => input)
+end

--- a/spec/rspec/failure_matcher_spec.rb
+++ b/spec/rspec/failure_matcher_spec.rb
@@ -393,16 +393,6 @@ describe Salestation::RSpec::FailureMatcher do
       end
 
       it 'fails when one field message of multiple field messages does not match' do
-        validation_result = schema.call(filters: {name: nil, email: 1})
-
-        failure = Failure(
-          Errors::InvalidInput.from(
-            Glia::Errors.from_dry_validation_result(validation_result),
-            errors: validation_result.errors.to_h,
-            hints: {}
-          )
-        )
-
         expect(
           matcher
             .with_invalid_input


### PR DESCRIPTION
This allows writing more thorough tests, where unexpected failures will
cause tests to fail when `.exactly` is added to the chain.

QVA-182

