### PR TITLE
Test for Ruby 3.1 and 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,15 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      # Automatically get bug fixes and new Ruby versions for ruby/setup-ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/lib/salestation/app.rb
+++ b/lib/salestation/app.rb
@@ -7,12 +7,7 @@ require 'dry-types'
 module Salestation
   class App
     module Types
-      dry_types_version = Gem.loaded_specs['dry-types'].version
-      if dry_types_version < Gem::Version.new('0.15.0')
-        include Dry::Types.module
-      else
-        include Dry::Types()
-      end
+      include Dry::Types()
     end
 
     def initialize(env:, hooks: {})

--- a/lib/salestation/web.rb
+++ b/lib/salestation/web.rb
@@ -8,12 +8,7 @@ require 'json'
 module Salestation
   class Web < Module
     module Types
-      dry_types_version = Gem.loaded_specs['dry-types'].version
-      if dry_types_version < Gem::Version.new('0.15.0')
-        include Dry::Types.module
-      else
-        include Dry::Types()
-      end
+      include Dry::Types()
     end
 
     def initialize(errors: {})

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.3.2"
+  spec.version       = "5.3.3"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["techmovers@glia.com"]
 


### PR DESCRIPTION
Adding Ruby 3.1 and 3.2 to the testing CI to make sure that these versions don't have any hidden bugs in them. 

Also, found some old code that can be reverted, because all services are on dry-* v1+. 