### PR TITLE
Add glia headers to log metadata

### DIFF
--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -13,6 +13,8 @@ module Salestation
       HTTP_ACCEPT = 'HTTP_ACCEPT'
       HTTP_ORIGIN = 'HTTP_ORIGIN'
       SERVER_NAME = 'SERVER_NAME'
+      GLIA_ACCOUNT_ID = 'HTTP_GLIA_ACCOUNT_ID'
+      GLIA_USER_ID = 'HTTP_GLIA_USER_ID'
 
       def initialize(app, logger, log_response_body: false, level: :info)
         @app = app
@@ -47,18 +49,20 @@ module Salestation
 
       def response_log(env, status, headers, body, began_at)
         log = {
-          remote_addr:  env[REMOTE_ADDR],
-          method:       env[REQUEST_METHOD],
-          path:         env[REQUEST_URI],
-          query:        env[QUERY_STRING],
-          content_type: env[CONTENT_TYPE],
-          http_agent:   env[HTTP_USER_AGENT],
-          http_accept:  env[HTTP_ACCEPT],
-          http_origin:  env[HTTP_ORIGIN],
-          server_name:  env[SERVER_NAME],
-          status:       status,
-          duration:     duration(from: began_at),
-          headers:      headers
+          remote_addr:     env[REMOTE_ADDR],
+          method:          env[REQUEST_METHOD],
+          path:            env[REQUEST_URI],
+          query:           env[QUERY_STRING],
+          content_type:    env[CONTENT_TYPE],
+          http_agent:      env[HTTP_USER_AGENT],
+          http_accept:     env[HTTP_ACCEPT],
+          http_origin:     env[HTTP_ORIGIN],
+          server_name:     env[SERVER_NAME],
+          status:          status,
+          duration:        duration(from: began_at),
+          glia_account_id: env[GLIA_ACCOUNT_ID],
+          glia_user_id:    env[GLIA_USER_ID],
+          headers:         headers
         }
 
         if status >= 400

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.3.3"
+  spec.version       = "5.4.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["open-source@glia.com"]
 

--- a/spec/salestation/web/request_logger_spec.rb
+++ b/spec/salestation/web/request_logger_spec.rb
@@ -99,5 +99,18 @@ describe Salestation::Web::RequestLogger do
         middleware.call(status: 400, body: error)
       end
     end
+
+    it 'logs Glia-Account-Id and Glia-User-Id headers' do
+      middleware = described_class.new(web_app, logger)
+      account_id = 'account-id'
+      user_id = 'user-id'
+
+      expect(logger).to receive(:info).with(
+        'Processed request',
+        a_hash_including(glia_account_id: account_id, glia_user_id: user_id)
+      )
+
+      middleware.call(body: '{}', 'HTTP_GLIA_ACCOUNT_ID' => account_id, 'HTTP_GLIA_USER_ID' => user_id)
+    end
   end
 end


### PR DESCRIPTION
Helps to attribute requests to accounts and users.