### PR TITLE
Allow adding arbitrary log fields via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ class Webapp < Sinatra::Base
 end
 ```
 
+You can configure per-request fields by defining `salestation.request_logger.fields` in sinatra `env`:
+
+```ruby
+  def my_handler(env)
+    env['salestation.request_logger.fields'] = { foo: 'bar' }
+    # ...
+  end
+```
+
 ### Using StatsD
 
 Salestation provides a StatsD middleware which can be used record request

--- a/lib/salestation/web/request_logger.rb
+++ b/lib/salestation/web/request_logger.rb
@@ -3,6 +3,8 @@
 module Salestation
   class Web < Module
     class RequestLogger
+      EXTRA_FIELDS_ENV_KEY = 'salestation.request_logger.fields'
+
       DURATION_PRECISION = 6
       REMOTE_ADDR = 'REMOTE_ADDR'
       REQUEST_URI = 'REQUEST_URI'
@@ -71,7 +73,8 @@ module Salestation
           log[:body] = body.join
         end
 
-        log
+        extra_fields = env.fetch(EXTRA_FIELDS_ENV_KEY, {})
+        log.merge!(extra_fields)
       end
 
       def duration(from:)

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.4.0"
+  spec.version       = "5.5.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["open-source@glia.com"]
 

--- a/spec/salestation/web/request_logger_spec.rb
+++ b/spec/salestation/web/request_logger_spec.rb
@@ -112,5 +112,16 @@ describe Salestation::Web::RequestLogger do
 
       middleware.call(body: '{}', 'HTTP_GLIA_ACCOUNT_ID' => account_id, 'HTTP_GLIA_USER_ID' => user_id)
     end
+
+    it 'logs arbitrary extra fields set in the env' do
+      middleware = described_class.new(web_app, logger)
+
+      expect(logger).to receive(:info).with(
+        'Processed request',
+        a_hash_including(arbitrary_field: 'example_value')
+      )
+
+      middleware.call(body: '{}', 'salestation.request_logger.fields' => { arbitrary_field: 'example_value' })
+    end
   end
 end


### PR DESCRIPTION
We have an application-specific field that we want to add to the logs from `RequestLogger`.

The solution here is the same that's used for `StatsdMiddleware`: the application can put arbitrary logging fields in `env` under a special key `salestation.request_logger.fields` and the logger will merge them.