### PR TITLE
Change HTTP request duration metric type to distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 6.0.0
+
+### Changed
+
+- **Breaking change**: Change StatsdMiddleware metric type from timing to
+  distribution. Prior to 6.0.0, if you set the metric name to
+  `my_service.response.time`, then in Datadog you ended up with metrics
+  `my_service.response.time.avg`, `my_service.response.time.95_percentile`,
+  `my_service.response.time.count`. Now, only one metric with name
+   `my_service.response.time` of type distribution is sent.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ You can configure per-request fields by defining `salestation.request_logger.fie
 ### Using StatsD
 
 Salestation provides a StatsD middleware which can be used record request
-execution time. A `timing` call with elapsed seconds is made to the provided
+execution time. A `distribution` call with elapsed seconds is made to the provided
 StatsD instance with `path`, `method`, `status` and `status_class` tags.
 
 ```ruby

--- a/lib/salestation/web/statsd_middleware.rb
+++ b/lib/salestation/web/statsd_middleware.rb
@@ -33,7 +33,7 @@ module Salestation
           "status_class:#{status / 100}xx"
         ] + env.fetch(EXTRA_TAGS_ENV_KEY, [])
 
-        @statsd.timing(@metric, duration_ms(from: start), tags: tags)
+        @statsd.distribution(@metric, duration_ms(from: start), tags: tags)
 
         [status, header, body]
       end

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "5.5.0"
+  spec.version       = "6.0.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["open-source@glia.com"]
 

--- a/spec/salestation/web/statsd_middleware_spec.rb
+++ b/spec/salestation/web/statsd_middleware_spec.rb
@@ -20,7 +20,7 @@ describe Salestation::Web::StatsdMiddleware do
     it 'records status and status class' do
       middleware = described_class.new(web_app, statsd, metric: 'test.req')
 
-      expect(statsd).to receive(:timing)
+      expect(statsd).to receive(:distribution)
         .with(
           'test.req',
           instance_of(Float),


### PR DESCRIPTION
The distribution metric type is better since aggregation happens in Datadog server and there is no early aggregation done in the Datadog agent. Thus, you can view the distribution of data more accurately than and also in other formats besides time series.

AUTO-1835