### PR TITLE
Support ActiveRecord versions above 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 6.1.0
+
+### Fixed
+
+- Fix incompatibility with ActiveRecord 7.1+ due to changes in its
+  connection clearing API.
+
 ## 6.0.0
 
 ### Changed

--- a/lib/salestation/web/active_record_connection_management.rb
+++ b/lib/salestation/web/active_record_connection_management.rb
@@ -12,12 +12,22 @@ module Salestation
 
         status, headers, body = @app.call(env)
         proxy = ::Rack::BodyProxy.new(body) do
-          ActiveRecord::Base.clear_active_connections! unless testing
+          clear_connections unless testing
         end
         [status, headers, proxy]
       rescue Exception
-        ActiveRecord::Base.clear_active_connections! unless testing
+        clear_connections unless testing
         raise
+      end
+
+      def clear_connections
+        if ActiveRecord::Base.respond_to?(:clear_active_connections!)
+          # For ActiveRecord 6.1 to 7.0
+          ActiveRecord::Base.clear_active_connections!
+        else
+          # For ActiveRecord 7.1 and newer
+          ActiveRecord::Base.connection_handler.clear_active_connections!
+        end
       end
     end
   end


### PR DESCRIPTION
Fix incompatibility with ActiveRecord 7.1+ due to changes in its connection clearing API.