### PR TITLE
Fix publish gem ci failing

### DIFF
--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 2.0", "< 5"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.14.2"


### PR DESCRIPTION
allow bundler newer version to stop ci from failing and successfully relese gem.