### PR TITLE
Fix clear_active_connections! deprecation on Rails 7.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 6.2.0
+
+### Changed
+
+- `ActiveRecordConnectionManagement` now passes `:all` to
+  `clear_active_connections!` on AR 7.1+, silencing the deprecation
+  warning emitted on every HTTP request. **Behavior change**:
+  connections in non-writing roles (e.g. `:readonly`, `:analytics`)
+  are now also released at request end, matching AR 7.2's future
+  default and the middleware's intent of freeing all DB connections
+  per request.
+
 ## 6.1.0
 
 ### Fixed

--- a/lib/salestation/web/active_record_connection_management.rb
+++ b/lib/salestation/web/active_record_connection_management.rb
@@ -22,8 +22,9 @@ module Salestation
 
       def clear_connections
         if ActiveRecord.version >= Gem::Version.new('7.1')
-          # For ActiveRecord 7.1 and newer
-          ActiveRecord::Base.connection_handler.clear_active_connections!
+          # For ActiveRecord 7.1 and newer. Pass :all to clear all roles,
+          # matching AR 7.2's future default.
+          ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
         else
           # For ActiveRecord 6.1 to 7.0
           ActiveRecord::Base.clear_active_connections!

--- a/salestation.gemspec
+++ b/salestation.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "salestation"
-  spec.version       = "6.1.1"
+  spec.version       = "6.2.0"
   spec.authors       = ["Glia TechMovers"]
   spec.email         = ["open-source@glia.com"]
 


### PR DESCRIPTION
Silence the deprecation warning emitted from `ActiveRecordConnectionManagement` on every HTTP request in AR 7.1.

Previously, the 7.1+ branch called `clear_active_connections!` without a role argument, which only cleared the `:writing` pool and emitted a DeprecationWarning (the default changes from `:writing` to `:all` in AR 7.2).
Now, `:all` is passed explicitly. This is a behavior change — connections in non-writing roles (e.g. `:readonly`, `:analytics`) are now also released. This matches AR 7.2's future default and the middleware's intent of freeing all DB connections at request end.
AR 6.1/7.0 behavior is unchanged.

ATL-951